### PR TITLE
Add SQL Parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,17 @@
         <maven.compiler.source>22</maven.compiler.source>
         <maven.compiler.target>22</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <jsqlparser.version>5.0</jsqlparser.version>
     </properties>
+
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/com.github.jsqlparser/jsqlparser -->
+        <dependency>
+            <groupId>com.github.jsqlparser</groupId>
+            <artifactId>jsqlparser</artifactId>
+            <version>${jsqlparser.version}</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/src/main/java/com/miljanilic/Application.java
+++ b/src/main/java/com/miljanilic/Application.java
@@ -1,12 +1,34 @@
 package com.miljanilic;
 
 import com.google.inject.Inject;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+import com.miljanilic.sql.ast.statement.Statement;
+import com.miljanilic.sql.parser.SQLParser;
+import com.miljanilic.sql.parser.SQLParserException;
+
+import java.util.Scanner;
 
 public class Application {
+    private final SQLParser sqlParser;
+
     @Inject
-    public Application() {}
+    public Application(SQLParser sqlParser) {
+        this.sqlParser = sqlParser;
+    }
 
     public void run() {
-        System.out.println("Hello World!");
+        Scanner scanner = new Scanner(System.in);
+
+        String sql = scanner.nextLine();
+
+        try {
+            Statement statement = sqlParser.parse(sql);
+
+            if (statement instanceof SelectStatement) {
+                System.out.println(statement);
+            }
+        } catch (SQLParserException e) {
+            System.out.println("Error parsing SQL: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/miljanilic/Main.java
+++ b/src/main/java/com/miljanilic/Main.java
@@ -2,10 +2,11 @@ package com.miljanilic;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import module.SQLModule;
 
 public class Main {
     public static void main(String[] args) {
-        Injector injector = Guice.createInjector();
+        Injector injector = Guice.createInjector(new SQLModule());
         Application app = injector.getInstance(Application.class);
 
         app.run();

--- a/src/main/java/com/miljanilic/sql/parser/JSQLParser.java
+++ b/src/main/java/com/miljanilic/sql/parser/JSQLParser.java
@@ -1,0 +1,50 @@
+package com.miljanilic.sql.parser;
+
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.node.*;
+import com.miljanilic.sql.ast.node.Select;
+import com.miljanilic.sql.ast.statement.Statement;
+import com.miljanilic.sql.parser.resolver.JSQLJoinTypeResolver;
+import com.miljanilic.sql.parser.visitor.*;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.*;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.select.*;
+
+public class JSQLParser implements SQLParser {
+
+    public Statement parse(String sql) {
+        try {
+            net.sf.jsqlparser.statement.Statement statement = CCJSqlParserUtil.parse(sql);
+
+            if (statement instanceof net.sf.jsqlparser.statement.select.Select) {
+                return visit((net.sf.jsqlparser.statement.select.Select) statement);
+            }
+
+            throw new UnsupportedOperationException("Only SELECT statements are supported.");
+        } catch (JSQLParserException e) {
+            throw new SQLParserException("Error parsing SQL: " + e.getMessage(), e);
+        }
+    }
+
+    public Statement visit(net.sf.jsqlparser.statement.select.Select select) {
+        PlainSelect plainSelect = select.getPlainSelect();
+
+        FromItemVisitor<From> fromItemVisitor = new JSQLFromItemVisitor();
+        ExpressionVisitor<Expression> expressionVisitor = new JSQLExpressionVisitor(fromItemVisitor);
+        SelectItemVisitor<Select> selectItemVisitor = new JSQLSelectItemVisitor(expressionVisitor);
+        GroupByVisitor<GroupBy> groupByVisitor = new JSQLGroupByVisitor(expressionVisitor);
+        OrderByVisitor<OrderBy> orderByVisitor = new JSQLOrderByVisitor(expressionVisitor);
+        JSQLJoinTypeResolver joinTypeResolver = new JSQLJoinTypeResolver();
+        SelectVisitor<Statement> selectVisitor = new JSQLSelectVisitor(
+                selectItemVisitor,
+                fromItemVisitor,
+                groupByVisitor,
+                orderByVisitor,
+                expressionVisitor,
+                joinTypeResolver
+        );
+
+        return plainSelect.accept(selectVisitor, null);
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/SQLParser.java
+++ b/src/main/java/com/miljanilic/sql/parser/SQLParser.java
@@ -1,0 +1,7 @@
+package com.miljanilic.sql.parser;
+
+import com.miljanilic.sql.ast.statement.Statement;
+
+public interface SQLParser {
+    Statement parse(String sql);
+}

--- a/src/main/java/com/miljanilic/sql/parser/SQLParserException.java
+++ b/src/main/java/com/miljanilic/sql/parser/SQLParserException.java
@@ -1,0 +1,11 @@
+package com.miljanilic.sql.parser;
+
+public class SQLParserException extends RuntimeException {
+    public SQLParserException(String message) {
+        super(message);
+    }
+
+    public SQLParserException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/resolver/JSQLJoinTypeResolver.java
+++ b/src/main/java/com/miljanilic/sql/parser/resolver/JSQLJoinTypeResolver.java
@@ -1,0 +1,28 @@
+package com.miljanilic.sql.parser.resolver;
+
+import com.miljanilic.sql.ast.node.Join;
+
+public class JSQLJoinTypeResolver {
+
+    public Join.JoinType resolveJoinType(net.sf.jsqlparser.statement.select.Join join) {
+        if (join.isInner()) {
+            return Join.JoinType.INNER;
+        } else if (join.isLeft()) {
+            return Join.JoinType.LEFT;
+        } else if (join.isRight()) {
+            return Join.JoinType.RIGHT;
+        } else if (join.isFull()) {
+            return Join.JoinType.FULL;
+        } else if (join.isCross()) {
+            return Join.JoinType.CROSS;
+        } else if (join.isNatural()) {
+            throw new UnsupportedOperationException("NATURAL JOIN is not supported.");
+        } else if (join.isSemi()) {
+            throw new UnsupportedOperationException("SEMI JOIN is not supported.");
+        } else if (join.isOuter()) {
+            throw new UnsupportedOperationException("OUTER JOIN without LEFT/RIGHT/FULL specification is not supported.");
+        } else {
+            throw new UnsupportedOperationException("Unknown join type.");
+        }
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLExpressionVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLExpressionVisitor.java
@@ -24,7 +24,10 @@ public class JSQLExpressionVisitor extends ExpressionVisitorAdapter<Expression> 
 
     @Override
     public <S> Expression visit(net.sf.jsqlparser.schema.Column column, S context) {
-        return new Column(column.getColumnName(), column.getTable().accept(this.fromItemVisitor, context));
+        return new Column(
+                column.getColumnName(),
+                column.getTable() != null ? column.getTable().accept(this.fromItemVisitor, context) : null
+        );
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLExpressionVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLExpressionVisitor.java
@@ -1,5 +1,7 @@
 package com.miljanilic.sql.parser.visitor;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.miljanilic.sql.ast.expression.*;
 import com.miljanilic.sql.ast.expression.binary.*;
 import com.miljanilic.sql.ast.node.From;
@@ -15,9 +17,11 @@ import net.sf.jsqlparser.statement.select.FromItemVisitor;
 import java.util.ArrayList;
 import java.util.List;
 
+@Singleton
 public class JSQLExpressionVisitor extends ExpressionVisitorAdapter<Expression> {
     private final FromItemVisitor<From> fromItemVisitor;
 
+    @Inject
     public JSQLExpressionVisitor(FromItemVisitor<From> fromItemVisitor) {
         this.fromItemVisitor = fromItemVisitor;
     }

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLExpressionVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLExpressionVisitor.java
@@ -1,0 +1,171 @@
+package com.miljanilic.sql.parser.visitor;
+
+import com.miljanilic.sql.ast.expression.*;
+import com.miljanilic.sql.ast.expression.binary.*;
+import com.miljanilic.sql.ast.node.From;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
+import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.relational.MinorThan;
+import net.sf.jsqlparser.expression.operators.relational.MinorThanEquals;
+import net.sf.jsqlparser.statement.select.AllColumns;
+import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.FromItemVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JSQLExpressionVisitor extends ExpressionVisitorAdapter<Expression> {
+    private final FromItemVisitor<From> fromItemVisitor;
+
+    public JSQLExpressionVisitor(FromItemVisitor<From> fromItemVisitor) {
+        this.fromItemVisitor = fromItemVisitor;
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.schema.Column column, S context) {
+        return new Column(column.getColumnName(), column.getTable().accept(this.fromItemVisitor, context));
+    }
+
+    @Override
+    public <S> Expression visit(AllColumns allColumns, S context) {
+        return new Column(allColumns.toString(), null);
+    }
+
+    @Override
+    public <S> Expression visit(AllTableColumns allTableColumns, S context) {
+        return new Column(allTableColumns.toString(), allTableColumns.getTable().accept(this.fromItemVisitor, context));
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.LongValue longValue, S context) {
+        return new LongValue(longValue.getValue());
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.StringValue stringValue, S context) {
+        return new StringValue(stringValue.getValue());
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.relational.EqualsTo equalsTo, S context) {
+        return new EqualsTo(
+                equalsTo.getLeftExpression().accept(this, context),
+                equalsTo.getRightExpression().accept(this, context)
+        );
+    }
+
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.relational.NotEqualsTo notEqualsTo, S context) {
+        return new NotEqualsTo(
+                notEqualsTo.getLeftExpression().accept(this, context),
+                notEqualsTo.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.relational.GreaterThan greaterThan, S context) {
+        return new GreaterThan(
+                greaterThan.getLeftExpression().accept(this, context),
+                greaterThan.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.relational.GreaterThanEquals greaterThanEquals, S context) {
+        return new GreaterThanEquals(
+                greaterThanEquals.getLeftExpression().accept(this, context),
+                greaterThanEquals.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(MinorThan minorThan, S context) {
+        return new LessThan(
+                minorThan.getLeftExpression().accept(this, context),
+                minorThan.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(MinorThanEquals minorThanEquals, S context) {
+        return new LessThanEquals(
+                minorThanEquals.getLeftExpression().accept(this, context),
+                minorThanEquals.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.arithmetic.Addition addition, S context) {
+        return new Addition(
+                addition.getLeftExpression().accept(this, context),
+                addition.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.arithmetic.Division division, S context) {
+        return new Division(
+                division.getLeftExpression().accept(this, context),
+                division.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.arithmetic.Modulo modulo, S context) {
+        return new Modulo(
+                modulo.getLeftExpression().accept(this, context),
+                modulo.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.arithmetic.Multiplication multiplication, S context) {
+        return new Multiplication(
+                multiplication.getLeftExpression().accept(this, context),
+                multiplication.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.arithmetic.Subtraction subtraction, S context) {
+        return new Subtraction(
+                subtraction.getLeftExpression().accept(this, context),
+                subtraction.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(AndExpression andExpression, S context) {
+        return new AndOperator(
+                andExpression.getLeftExpression().accept(this, context),
+                andExpression.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(OrExpression orExpression, S context) {
+        return new OrOperator(
+                orExpression.getLeftExpression().accept(this, context),
+                orExpression.getRightExpression().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.Function function, S context) {
+        return new Function(
+                function.getName(),
+                function.getParameters().accept(this, context)
+        );
+    }
+
+    @Override
+    public <S> Expression visit(net.sf.jsqlparser.expression.operators.relational.ExpressionList<? extends net.sf.jsqlparser.expression.Expression> expressionList, S context) {
+        List<Expression> expressions = new ArrayList<>();
+
+        for (net.sf.jsqlparser.expression.Expression expr : expressionList) {
+            expressions.add(expr.accept(this, context));
+        }
+
+        return new ExpressionList(expressions);
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLFromItemVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLFromItemVisitor.java
@@ -1,9 +1,11 @@
 package com.miljanilic.sql.parser.visitor;
 
+import com.google.inject.Singleton;
 import com.miljanilic.sql.ast.node.From;
 import com.miljanilic.sql.ast.node.Table;
 import net.sf.jsqlparser.statement.select.FromItemVisitorAdapter;
 
+@Singleton
 public class JSQLFromItemVisitor extends FromItemVisitorAdapter<From> {
     @Override
     public <S> From visit(net.sf.jsqlparser.schema.Table table, S context) {

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLFromItemVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLFromItemVisitor.java
@@ -1,0 +1,15 @@
+package com.miljanilic.sql.parser.visitor;
+
+import com.miljanilic.sql.ast.node.From;
+import com.miljanilic.sql.ast.node.Table;
+import net.sf.jsqlparser.statement.select.FromItemVisitorAdapter;
+
+public class JSQLFromItemVisitor extends FromItemVisitorAdapter<From> {
+    @Override
+    public <S> From visit(net.sf.jsqlparser.schema.Table table, S context) {
+        return new Table(
+                table.getName(),
+                table.getAlias() != null ? table.getAlias().getName() : null
+        );
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLGroupByVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLGroupByVisitor.java
@@ -17,6 +17,10 @@ public class JSQLGroupByVisitor implements GroupByVisitor<GroupBy> {
 
     @Override
     public <S> GroupBy visit(GroupByElement groupByElement, S context) {
+        if (!groupByElement.getGroupingSets().isEmpty()) {
+            throw new UnsupportedOperationException("GROUPING SETS are not supported.");
+        }
+
         ExpressionList<?> expressionList = (ExpressionList<?>) groupByElement.getGroupByExpressionList();
         return new SimpleGroupBy(expressionList.accept(expressionVisitor, context));
     }

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLGroupByVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLGroupByVisitor.java
@@ -1,5 +1,7 @@
 package com.miljanilic.sql.parser.visitor;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.miljanilic.sql.ast.expression.Expression;
 import com.miljanilic.sql.ast.node.GroupBy;
 import com.miljanilic.sql.ast.node.SimpleGroupBy;
@@ -8,9 +10,11 @@ import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.statement.select.GroupByElement;
 import net.sf.jsqlparser.statement.select.GroupByVisitor;
 
+@Singleton
 public class JSQLGroupByVisitor implements GroupByVisitor<GroupBy> {
     private final ExpressionVisitor<Expression> expressionVisitor;
 
+    @Inject
     public JSQLGroupByVisitor(ExpressionVisitor<Expression> expressionVisitor) {
         this.expressionVisitor = expressionVisitor;
     }

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLGroupByVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLGroupByVisitor.java
@@ -1,0 +1,23 @@
+package com.miljanilic.sql.parser.visitor;
+
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.node.GroupBy;
+import com.miljanilic.sql.ast.node.SimpleGroupBy;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.statement.select.GroupByElement;
+import net.sf.jsqlparser.statement.select.GroupByVisitor;
+
+public class JSQLGroupByVisitor implements GroupByVisitor<GroupBy> {
+    private final ExpressionVisitor<Expression> expressionVisitor;
+
+    public JSQLGroupByVisitor(ExpressionVisitor<Expression> expressionVisitor) {
+        this.expressionVisitor = expressionVisitor;
+    }
+
+    @Override
+    public <S> GroupBy visit(GroupByElement groupByElement, S context) {
+        ExpressionList<?> expressionList = (ExpressionList<?>) groupByElement.getGroupByExpressionList();
+        return new SimpleGroupBy(expressionList.accept(expressionVisitor, context));
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLOrderByVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLOrderByVisitor.java
@@ -16,6 +16,10 @@ public class JSQLOrderByVisitor implements OrderByVisitor<OrderBy> {
 
     @Override
     public <S> OrderBy visit(OrderByElement orderByElement, S context) {
+        if (orderByElement.getNullOrdering() != null) {
+            throw new UnsupportedOperationException("NULL ordering in ORDER BY is not supported.");
+        }
+
         return new SimpleOrderBy(orderByElement.getExpression().accept(this.expressionVisitor, context), orderByElement.isAsc());
     }
 }

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLOrderByVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLOrderByVisitor.java
@@ -1,5 +1,7 @@
 package com.miljanilic.sql.parser.visitor;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.miljanilic.sql.ast.expression.Expression;
 import com.miljanilic.sql.ast.node.OrderBy;
 import com.miljanilic.sql.ast.node.SimpleOrderBy;
@@ -7,9 +9,11 @@ import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.OrderByVisitor;
 
+@Singleton
 public class JSQLOrderByVisitor implements OrderByVisitor<OrderBy> {
     private final ExpressionVisitor<Expression> expressionVisitor;
 
+    @Inject
     public JSQLOrderByVisitor(ExpressionVisitor<Expression> expressionVisitor) {
         this.expressionVisitor = expressionVisitor;
     }

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLOrderByVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLOrderByVisitor.java
@@ -1,0 +1,21 @@
+package com.miljanilic.sql.parser.visitor;
+
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.node.OrderBy;
+import com.miljanilic.sql.ast.node.SimpleOrderBy;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.select.OrderByElement;
+import net.sf.jsqlparser.statement.select.OrderByVisitor;
+
+public class JSQLOrderByVisitor implements OrderByVisitor<OrderBy> {
+    private final ExpressionVisitor<Expression> expressionVisitor;
+
+    public JSQLOrderByVisitor(ExpressionVisitor<Expression> expressionVisitor) {
+        this.expressionVisitor = expressionVisitor;
+    }
+
+    @Override
+    public <S> OrderBy visit(OrderByElement orderByElement, S context) {
+        return new SimpleOrderBy(orderByElement.getExpression().accept(this.expressionVisitor, context), orderByElement.isAsc());
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLSelectItemVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLSelectItemVisitor.java
@@ -1,0 +1,24 @@
+package com.miljanilic.sql.parser.visitor;
+
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.node.Select;
+import com.miljanilic.sql.ast.node.SimpleSelect;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.select.SelectItem;
+import net.sf.jsqlparser.statement.select.SelectItemVisitorAdapter;
+
+public class JSQLSelectItemVisitor extends SelectItemVisitorAdapter<Select> {
+    private final ExpressionVisitor<Expression> expressionVisitor;
+
+    public JSQLSelectItemVisitor(ExpressionVisitor<Expression> expressionVisitor) {
+        this.expressionVisitor = expressionVisitor;
+    }
+
+    @Override
+    public <S> Select visit(SelectItem<? extends net.sf.jsqlparser.expression.Expression> item, S context) {
+        return new SimpleSelect(
+                item.getExpression().accept(this.expressionVisitor, context),
+                item.getAlias() != null ? item.getAlias().getName() : null
+        );
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLSelectItemVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLSelectItemVisitor.java
@@ -1,5 +1,7 @@
 package com.miljanilic.sql.parser.visitor;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.miljanilic.sql.ast.expression.Expression;
 import com.miljanilic.sql.ast.node.Select;
 import com.miljanilic.sql.ast.node.SimpleSelect;
@@ -7,9 +9,11 @@ import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.statement.select.SelectItem;
 import net.sf.jsqlparser.statement.select.SelectItemVisitorAdapter;
 
+@Singleton
 public class JSQLSelectItemVisitor extends SelectItemVisitorAdapter<Select> {
     private final ExpressionVisitor<Expression> expressionVisitor;
 
+    @Inject
     public JSQLSelectItemVisitor(ExpressionVisitor<Expression> expressionVisitor) {
         this.expressionVisitor = expressionVisitor;
     }

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLSelectVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLSelectVisitor.java
@@ -1,0 +1,90 @@
+package com.miljanilic.sql.parser.visitor;
+
+import com.miljanilic.sql.ast.clause.*;
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.expression.ExpressionList;
+import com.miljanilic.sql.ast.node.*;
+import com.miljanilic.sql.ast.node.Join;
+import com.miljanilic.sql.ast.node.Select;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+import com.miljanilic.sql.ast.statement.Statement;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.select.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JSQLSelectVisitor extends SelectVisitorAdapter<Statement> {
+    private final SelectItemVisitor<Select> selectItemVisitor;
+    private final FromItemVisitor<From> fromItemVisitor;
+    private final GroupByVisitor<GroupBy> groupByVisitor;
+    private final OrderByVisitor<OrderBy> orderByVisitor;
+    private final ExpressionVisitor<Expression> expressionVisitor;
+
+    public JSQLSelectVisitor(
+            SelectItemVisitor<Select> selectItemVisitor,
+            FromItemVisitor<From> fromItemVisitor,
+            GroupByVisitor<GroupBy> groupByVisitor,
+            OrderByVisitor<OrderBy> orderByVisitor,
+            ExpressionVisitor<Expression> expressionVisitor
+    ) {
+        this.selectItemVisitor = selectItemVisitor;
+        this.fromItemVisitor = fromItemVisitor;
+        this.groupByVisitor = groupByVisitor;
+        this.orderByVisitor = orderByVisitor;
+        this.expressionVisitor = expressionVisitor;
+    }
+
+    @Override
+    public <S> Statement visit(PlainSelect plainSelect, S context) {
+        SelectClause selectClause = new SelectClause(this.visitSelectItems(plainSelect.getSelectItems(), context));
+        FromClause fromClause = new FromClause(plainSelect.getFromItem().accept(this.fromItemVisitor, context));
+        JoinClause joinClause = new JoinClause(this.visitJoinItems(plainSelect.getJoins(), context));
+        WhereClause whereClause = new WhereClause(plainSelect.getWhere().accept(this.expressionVisitor, context));
+        GroupByClause groupByClause = new GroupByClause(plainSelect.getGroupBy().accept(this.groupByVisitor, context));
+        HavingClause havingClause = new HavingClause(plainSelect.getHaving().accept(this.expressionVisitor, context));
+        OrderByClause orderByClause = new OrderByClause(this.visitOrderByElements(plainSelect.getOrderByElements(), context));
+        LimitClause limitClause = new LimitClause(
+                plainSelect.getLimit().getRowCount().accept(this.expressionVisitor, context),
+                plainSelect.getLimit().getOffset() != null ? plainSelect.getLimit().getOffset().accept(this.expressionVisitor, context) : null
+        );
+
+        return new SelectStatement(
+                selectClause,
+                fromClause,
+                joinClause,
+                whereClause,
+                groupByClause,
+                havingClause,
+                orderByClause,
+                limitClause
+        );
+    }
+
+    private <S> List<Select> visitSelectItems(List<SelectItem<?>> selectItems, S context) {
+        return selectItems.stream()
+                .map(item -> item.accept(this.selectItemVisitor, context))
+                .collect(Collectors.toList());
+    }
+
+    private <S> List<Join> visitJoinItems(List<net.sf.jsqlparser.statement.select.Join> joins, S context) {
+        return joins.stream()
+                .map(join -> {
+                    List<Expression> expressions = new ArrayList<>();
+
+                    for (net.sf.jsqlparser.expression.Expression expression : join.getOnExpressions()) {
+                        expressions.add(expression.accept(this.expressionVisitor, context));
+                    }
+
+                    return new SimpleJoin(SimpleJoin.JoinType.INNER, join.getFromItem().accept(this.fromItemVisitor, context), new ExpressionList(expressions));
+                })
+                .collect(Collectors.toList());
+    }
+
+    private <S> List<OrderBy> visitOrderByElements(List<OrderByElement> orderByElements, S context) {
+        return orderByElements.stream()
+                .map(orderByElement -> orderByElement.accept(this.orderByVisitor, context))
+                .toList();
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLSelectVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLSelectVisitor.java
@@ -1,5 +1,7 @@
 package com.miljanilic.sql.parser.visitor;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.miljanilic.sql.ast.clause.*;
 import com.miljanilic.sql.ast.expression.Expression;
 import com.miljanilic.sql.ast.expression.ExpressionList;
@@ -16,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Singleton
 public class JSQLSelectVisitor extends SelectVisitorAdapter<Statement> {
     private final SelectItemVisitor<Select> selectItemVisitor;
     private final FromItemVisitor<From> fromItemVisitor;
@@ -24,6 +27,7 @@ public class JSQLSelectVisitor extends SelectVisitorAdapter<Statement> {
     private final ExpressionVisitor<Expression> expressionVisitor;
     private final JSQLJoinTypeResolver joinTypeResolver;
 
+    @Inject
     public JSQLSelectVisitor(
             SelectItemVisitor<Select> selectItemVisitor,
             FromItemVisitor<From> fromItemVisitor,

--- a/src/main/java/module/SQLModule.java
+++ b/src/main/java/module/SQLModule.java
@@ -1,0 +1,29 @@
+package module;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.node.From;
+import com.miljanilic.sql.ast.node.GroupBy;
+import com.miljanilic.sql.ast.node.OrderBy;
+import com.miljanilic.sql.ast.node.Select;
+import com.miljanilic.sql.ast.statement.Statement;
+import com.miljanilic.sql.parser.JSQLParser;
+import com.miljanilic.sql.parser.SQLParser;
+import com.miljanilic.sql.parser.visitor.*;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.select.*;
+
+public class SQLModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(SQLParser.class).to(JSQLParser.class);
+
+        bind(new TypeLiteral<SelectVisitor<Statement>>() {}).to(JSQLSelectVisitor.class);
+        bind(new TypeLiteral<SelectItemVisitor<Select>>() {}).to(JSQLSelectItemVisitor.class);
+        bind(new TypeLiteral<FromItemVisitor<From>>() {}).to(JSQLFromItemVisitor.class);
+        bind(new TypeLiteral<GroupByVisitor<GroupBy>>() {}).to(JSQLGroupByVisitor.class);
+        bind(new TypeLiteral<OrderByVisitor<OrderBy>>() {}).to(JSQLOrderByVisitor.class);
+        bind(new TypeLiteral<ExpressionVisitor<Expression>>() {}).to(JSQLExpressionVisitor.class);
+    }
+}


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

To enable the federated DuckDB system to understand and process SQL queries, we need a robust mechanism to parse SQL strings into a structured format. This change introduces a set of parsers and visitors that convert SQL queries into our custom Abstract Syntax Tree (AST) representation, allowing for efficient query analysis, transformation, and execution planning in a distributed environment.

# 💡 Solution (How?)

Implement a series of visitor classes with the `JSqlParser` library to convert its parse tree into our custom AST. Key components include:

`JSQLExpressionVisitor`: Handles conversion of SQL expressions.
`JSQLFromItemVisitor`: Processes FROM clause items, including tables and joins.
`JSQLGroupByVisitor`: Manages GROUP BY clause conversion.
`JSQLOrderByVisitor`: Handles ORDER BY clause parsing.
`JSQLSelectItemVisitor`: Processes items in the SELECT clause.
`JSQLSelectVisitor`: Orchestrates the overall SELECT statement conversion.

These visitors traverse the `JSqlParser` structure, creating corresponding nodes in AST.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
