### PR TITLE
Move Module to Main Package

### DIFF
--- a/src/main/java/com/miljanilic/Main.java
+++ b/src/main/java/com/miljanilic/Main.java
@@ -2,7 +2,7 @@ package com.miljanilic;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import module.SQLModule;
+import com.miljanilic.module.SQLModule;
 
 public class Main {
     public static void main(String[] args) {

--- a/src/main/java/com/miljanilic/module/SQLModule.java
+++ b/src/main/java/com/miljanilic/module/SQLModule.java
@@ -1,4 +1,4 @@
-package module;
+package com.miljanilic.module;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

The `SQLModule` is incorrectly placed outside the main package, causing potential confusion and violating our project's package naming conventions.

# 💡 Solution (How?)

Moved the `SQLModule` from the generic 'module' package to the project-specific 'com.miljanilic.module' package.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [x] **Bugfix** - A change that resolves an issue.
