### PR TITLE
Prevent NULL Exceptions w/ Valid SQL

### DIFF
--- a/src/main/java/com/miljanilic/sql/ast/clause/JoinClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/JoinClause.java
@@ -6,14 +6,14 @@ import com.miljanilic.sql.ast.node.Join;
 import java.util.List;
 
 public class JoinClause extends Clause {
-    private final List<Join> joins;
+    private final List<Join> joinList;
 
     public JoinClause(List<Join> joins) {
-        this.joins = joins;
+        this.joinList = joins;
     }
 
-    public List<Join> getJoins() {
-        return joins;
+    public List<Join> getJoinList() {
+        return joinList;
     }
 
     @Override
@@ -24,7 +24,7 @@ public class JoinClause extends Clause {
     @Override
     public String toString() {
         return "JoinClause{" +
-                "joins=" + joins +
+                "joinList=" + joinList +
                 '}';
     }
 }


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

The original `JSQLSelectVisitor` implementation is vulnerable to null pointer exceptions when parsing SQL statements with missing or optional clauses.

# 💡 Solution (How?)

Enhanced the `JSQLSelectVisitor` to handle potential null values gracefully. The solution leverages Java's Optional class and null-safe operations to ensure safer processing of SQL components.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [x] **Bugfix** - A change that resolves an issue.
