### PR TITLE
Fix Binary Expression Not Passing Operator

### DIFF
--- a/src/main/java/com/miljanilic/sql/ast/expression/binary/Binary.java
+++ b/src/main/java/com/miljanilic/sql/ast/expression/binary/Binary.java
@@ -5,11 +5,12 @@ import com.miljanilic.sql.ast.expression.Expression;
 
 public abstract class Binary extends Expression {
     private final Expression left;
-    private String operator;
+    private final String operator;
     private final Expression right;
 
     public Binary(Expression left, String operator, Expression right) {
         this.left = left;
+        this.operator = operator;
         this.right = right;
     }
 


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

Fix a bug in the `Binary` class constructor where the `operator` field was not initialized, potentially leading to unexpected behavior in binary expressions.

# 💡 Solution (How?)

Modify the `Binary` class constructor to properly initialize the `operator` field with the provided parameter. Additionally, change the `operator` field to be final, ensuring immutability and preventing accidental modifications after object creation.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [x] **Bugfix** - A change that resolves an issue.
