### PR TITLE
Improve `toString()` of Catalog Data Objects

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,13 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="ClassCanBeRecord" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="146" name="Java" />
+      </Languages>
+    </inspection_tool>
+    <inspection_tool class="ExtractMethodRecommender" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="StringBufferReplaceableByString" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="VulnerableLibrariesLocal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="isIgnoringEnabled" value="true" />
       <option name="ignoredModules">

--- a/src/main/java/com/miljanilic/catalog/data/Column.java
+++ b/src/main/java/com/miljanilic/catalog/data/Column.java
@@ -27,14 +27,6 @@ public class Column {
         this.type = type;
     }
 
-    @Override
-    public String toString() {
-        return "Column{" +
-                "name='" + name + '\'' +
-                ", type=" + type +
-                '}';
-    }
-
     public enum ColumnType {
         INTEGER,
         VARCHAR,
@@ -42,5 +34,11 @@ public class Column {
         DATE,
         DECIMAL
     }
-}
 
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append(name).append(" (").append(type).append(")")
+                .toString();
+    }
+}

--- a/src/main/java/com/miljanilic/catalog/data/DataSource.java
+++ b/src/main/java/com/miljanilic/catalog/data/DataSource.java
@@ -49,10 +49,9 @@ public class DataSource {
 
     @Override
     public String toString() {
-        return "DataSource{" +
-                "jdbcUrl='" + jdbcUrl + '\'' +
-                ", jdbcUser='" + jdbcUser + '\'' +
-                ", jdbcDriver='" + jdbcDriver + '\'' +
-                '}';
+        return new StringBuilder()
+                .append("JDBC URL: ").append(jdbcUrl).append("\n")
+                .append("Driver: ").append(jdbcDriver)
+                .toString();
     }
 }

--- a/src/main/java/com/miljanilic/catalog/data/Schema.java
+++ b/src/main/java/com/miljanilic/catalog/data/Schema.java
@@ -2,6 +2,7 @@ package com.miljanilic.catalog.data;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Schema {
     private String name;
@@ -44,10 +45,10 @@ public class Schema {
 
     @Override
     public String toString() {
-        return "Schema{" +
-                "name='" + name + '\'' +
-                ", dataSource=" + dataSource +
-                ", schemaTableList=" + tables +
-                '}';
+        StringBuilder sb = new StringBuilder();
+        sb.append("Schema: ").append(name).append("\n")
+                .append("Data Source: ").append(dataSource);
+
+        return sb.toString();
     }
 }

--- a/src/main/java/com/miljanilic/catalog/data/Table.java
+++ b/src/main/java/com/miljanilic/catalog/data/Table.java
@@ -1,6 +1,7 @@
 package com.miljanilic.catalog.data;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Table {
     private String name;
@@ -56,10 +57,19 @@ public class Table {
 
     @Override
     public String toString() {
-        return "SchemaTable{" +
-                "name='" + name + '\'' +
-                ", type=" + type +
-                ", sql='" + sql + '\'' +
-                '}';
+        StringBuilder sb = new StringBuilder();
+        sb.append("Table: ").append(name).append(" (").append(type).append(")\n")
+                .append("SQL: ").append(sql).append("\n")
+                .append("Columns: ");
+
+        if (columns != null && !columns.isEmpty()) {
+            sb.append(columns.stream()
+                    .map(Column::toString)
+                    .collect(Collectors.joining(", ")));
+        } else {
+            sb.append("No columns");
+        }
+
+        return sb.toString();
     }
 }


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

The existing `toString()` methods in several classes (`Column`, `DataSource`, `Schema`, `Table`) were overly verbose, inefficient, and lacked a concise output format. This made it difficult to read and understand the information when objects were printed or logged.

# 💡 Solution (How?)

- Refactored the `toString()` methods across multiple classes to use `StringBuilder` for more efficient string construction.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [x] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
