### PR TITLE
Add Setters to AST Clauses and Statements

### DIFF
--- a/src/main/java/com/miljanilic/sql/ast/clause/FromClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/FromClause.java
@@ -4,7 +4,7 @@ import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.node.From;
 
 public class FromClause extends Clause {
-    private final From from;
+    private From from;
 
     public FromClause(From from) {
         this.from = from;
@@ -12,6 +12,10 @@ public class FromClause extends Clause {
 
     public From getFrom() {
         return from;
+    }
+
+    public void setFrom(From from) {
+        this.from = from;
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/clause/GroupByClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/GroupByClause.java
@@ -4,7 +4,7 @@ import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.node.GroupBy;
 
 public class GroupByClause extends Clause {
-    private final GroupBy groupBy;
+    private GroupBy groupBy;
 
     public GroupByClause(GroupBy groupBy) {
         this.groupBy = groupBy;
@@ -12,6 +12,10 @@ public class GroupByClause extends Clause {
 
     public GroupBy getGroupBy() {
         return groupBy;
+    }
+
+    public void setGroupBy(GroupBy groupBy) {
+        this.groupBy = groupBy;
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/clause/HavingClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/HavingClause.java
@@ -4,7 +4,7 @@ import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.expression.Expression;
 
 public class HavingClause extends Clause {
-    private final Expression condition;
+    private Expression condition;
 
     public HavingClause(Expression condition) {
         this.condition = condition;
@@ -12,6 +12,10 @@ public class HavingClause extends Clause {
 
     public Expression getCondition() {
         return condition;
+    }
+
+    public void setCondition(Expression condition) {
+        this.condition = condition;
     }
 
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {

--- a/src/main/java/com/miljanilic/sql/ast/clause/JoinClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/JoinClause.java
@@ -7,14 +7,22 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class JoinClause extends Clause {
-    private final List<Join> joinList;
+    private List<Join> joinList;
 
     public JoinClause(List<Join> joins) {
         this.joinList = joins;
     }
 
+    public void addJoin(Join join) {
+        joinList.add(join);
+    }
+
     public List<Join> getJoinList() {
         return joinList;
+    }
+
+    public void setJoinList(List<Join> joinList) {
+        this.joinList = joinList;
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/clause/LimitClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/LimitClause.java
@@ -4,8 +4,8 @@ import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.expression.Expression;
 
 public class LimitClause extends Clause {
-    private final Expression limit;
-    private final Expression offset;
+    private Expression limit;
+    private Expression offset;
 
     public LimitClause(final Expression limit, final Expression offset) {
         this.limit = limit;
@@ -16,8 +16,16 @@ public class LimitClause extends Clause {
         return limit;
     }
 
+    public void setLimit(Expression limit) {
+        this.limit = limit;
+    }
+
     public Expression getOffset() {
         return offset;
+    }
+
+    public void setOffset(Expression offset) {
+        this.offset = offset;
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/clause/OrderByClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/OrderByClause.java
@@ -7,14 +7,22 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class OrderByClause extends Clause {
-    private final List<OrderBy> orderByList;
+    private List<OrderBy> orderByList;
 
     public OrderByClause(List<OrderBy> orderBylist) {
         this.orderByList = orderBylist;
     }
 
+    public void addOrderBy(OrderBy orderBy) {
+        orderByList.add(orderBy);
+    }
+
     public List<OrderBy> getOrderByList() {
         return orderByList;
+    }
+
+    public void setOrderByList(List<OrderBy> orderByList) {
+        this.orderByList = orderByList;
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/clause/SelectClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/SelectClause.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class SelectClause extends Clause {
-    private final List<Select> selectList;
+    private List<Select> selectList;
 
     public SelectClause() {
         this.selectList = new ArrayList<>();
@@ -18,8 +18,16 @@ public class SelectClause extends Clause {
         this.selectList = selectList;
     }
 
+    public void addSelect(Select select) {
+        selectList.add(select);
+    }
+
     public List<Select> getSelectList() {
         return selectList;
+    }
+
+    public void setSelectList(List<Select> selectList) {
+        this.selectList = selectList;
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/clause/WhereClause.java
+++ b/src/main/java/com/miljanilic/sql/ast/clause/WhereClause.java
@@ -4,7 +4,7 @@ import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.expression.Expression;
 
 public class WhereClause extends Clause {
-    private final Expression condition;
+    private Expression condition;
 
     public WhereClause(Expression condition) {
         this.condition = condition;
@@ -12,6 +12,10 @@ public class WhereClause extends Clause {
 
     public Expression getCondition() {
         return condition;
+    }
+
+    public void setCondition(Expression condition) {
+        this.condition = condition;
     }
 
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {

--- a/src/main/java/com/miljanilic/sql/ast/statement/SelectStatement.java
+++ b/src/main/java/com/miljanilic/sql/ast/statement/SelectStatement.java
@@ -4,14 +4,16 @@ import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.clause.*;
 
 public class SelectStatement extends Statement {
-    private final SelectClause selectClause;
-    private final FromClause fromClause;
-    private final JoinClause joinClause;
-    private final WhereClause whereClause;
-    private final GroupByClause groupByClause;
-    private final HavingClause havingClause;
-    private final OrderByClause orderByClause;
-    private final LimitClause limitClause;
+    private SelectClause selectClause;
+    private FromClause fromClause;
+    private JoinClause joinClause;
+    private WhereClause whereClause;
+    private GroupByClause groupByClause;
+    private HavingClause havingClause;
+    private OrderByClause orderByClause;
+    private LimitClause limitClause;
+
+    public SelectStatement() {}
 
     public SelectStatement(
             SelectClause selectClause,
@@ -37,32 +39,64 @@ public class SelectStatement extends Statement {
         return selectClause;
     }
 
+    public void setSelectClause(SelectClause selectClause) {
+        this.selectClause = selectClause;
+    }
+
     public FromClause getFromClause() {
         return fromClause;
+    }
+
+    public void setFromClause(FromClause fromClause) {
+        this.fromClause = fromClause;
     }
 
     public JoinClause getJoinClause() {
         return joinClause;
     }
 
+    public void setJoinClause(JoinClause joinClause) {
+        this.joinClause = joinClause;
+    }
+
     public WhereClause getWhereClause() {
         return whereClause;
+    }
+
+    public void setWhereClause(WhereClause whereClause) {
+        this.whereClause = whereClause;
     }
 
     public GroupByClause getGroupByClause() {
         return groupByClause;
     }
 
+    public void setGroupByClause(GroupByClause groupByClause) {
+        this.groupByClause = groupByClause;
+    }
+
     public HavingClause getHavingClause() {
         return havingClause;
+    }
+
+    public void setHavingClause(HavingClause havingClause) {
+        this.havingClause = havingClause;
     }
 
     public OrderByClause getOrderByClause() {
         return orderByClause;
     }
 
+    public void setOrderByClause(OrderByClause orderByClause) {
+        this.orderByClause = orderByClause;
+    }
+
     public LimitClause getLimitClause() {
         return limitClause;
+    }
+
+    public void setLimitClause(LimitClause limitClause) {
+        this.limitClause = limitClause;
     }
 
     @Override
@@ -74,14 +108,14 @@ public class SelectStatement extends Statement {
     public String toString() {
         StringBuilder sb = new StringBuilder("SELECT ");
 
-        sb.append(selectClause).append("\n");
-        sb.append("FROM ").append(fromClause).append("\n");
-        if (joinClause != null) sb.append(joinClause).append("\n");
-        if (whereClause != null) sb.append(whereClause).append("\n");
-        if (groupByClause != null) sb.append(groupByClause).append("\n");
-        if (havingClause != null) sb.append(havingClause).append("\n");
-        if (orderByClause != null) sb.append(orderByClause).append("\n");
-        if (limitClause != null) sb.append(limitClause);
+        sb.append(selectClause);
+        sb.append("\n").append("FROM ").append(fromClause);
+        if (joinClause != null) sb.append("\n").append(joinClause);
+        if (whereClause != null) sb.append("\n").append(whereClause);
+        if (groupByClause != null) sb.append("\n").append(groupByClause);
+        if (havingClause != null) sb.append("\n").append(havingClause);
+        if (orderByClause != null) sb.append("\n").append(orderByClause);
+        if (limitClause != null) sb.append("\n").append(limitClause);
 
         return sb.toString();
     }


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

This change's primary motivation is to increase flexibility and maintainability in the SQL AST (Abstract Syntax Tree) clause classes. 

# 💡 Solution (How?)

- Removed the `final` keyword from fields in the `FromClause`, `GroupByClause`, `HavingClause`, `JoinClause`, `LimitClause`, `OrderByClause`, `SelectClause`, and `WhereClause` classes.
- Introduced setter methods (`setFrom`, `setGroupBy`, `setCondition`, etc.) to allow modification of these fields.
- Updated the `SelectStatement` class to also have setter methods for each of its clauses (`setSelectClause`, `setFromClause`, etc.).
- Adjusted the `toString()` methods for better formatting and readability when generating SQL queries.

This change enables greater flexibility when constructing or modifying SQL statements programmatically, improving the usability of the SQL AST.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [x] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
