### PR TITLE
Add Schema to From Node

### DIFF
--- a/src/main/java/com/miljanilic/sql/ast/node/From.java
+++ b/src/main/java/com/miljanilic/sql/ast/node/From.java
@@ -1,8 +1,19 @@
 package com.miljanilic.sql.ast.node;
 
+import com.miljanilic.catalog.data.Schema;
 import com.miljanilic.sql.ast.ASTVisitor;
 
 public abstract class From extends Node {
+    protected final Schema schema;
+
+    protected From(Schema schema) {
+        this.schema = schema;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
     @Override
     public abstract <T, S> T accept(ASTVisitor<T, S> visitor, S context);
 }

--- a/src/main/java/com/miljanilic/sql/ast/node/Table.java
+++ b/src/main/java/com/miljanilic/sql/ast/node/Table.java
@@ -1,20 +1,16 @@
 package com.miljanilic.sql.ast.node;
 
+import com.miljanilic.catalog.data.Schema;
 import com.miljanilic.sql.ast.ASTVisitor;
 
 public class Table extends From {
-    private final String schema;
     private final String name;
     private final String alias;
 
-    public Table(String schema, String name, String alias) {
-        this.schema = schema;
+    public Table(Schema schema, String name, String alias) {
+        super(schema);
         this.name = name;
         this.alias = alias;
-    }
-
-    public String getSchema() {
-        return schema;
     }
 
     public String getName() {
@@ -31,6 +27,6 @@ public class Table extends From {
     }
 
     public String toString() {
-        return (schema != null ? schema + "." : "") + name + (alias != null ? " " + alias : "");
+        return (schema != null ? schema.getName() + "." : "") + name + (alias != null ? " " + alias : "");
     }
 }

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLFromItemVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLFromItemVisitor.java
@@ -1,16 +1,25 @@
 package com.miljanilic.sql.parser.visitor;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.miljanilic.catalog.SchemaRepository;
 import com.miljanilic.sql.ast.node.From;
 import com.miljanilic.sql.ast.node.Table;
 import net.sf.jsqlparser.statement.select.FromItemVisitorAdapter;
 
 @Singleton
 public class JSQLFromItemVisitor extends FromItemVisitorAdapter<From> {
+    private final SchemaRepository schemaRepository;
+
+    @Inject
+    public JSQLFromItemVisitor(SchemaRepository schemaRepository) {
+        this.schemaRepository = schemaRepository;
+    }
+
     @Override
     public <S> From visit(net.sf.jsqlparser.schema.Table table, S context) {
         return new Table(
-                table.getSchemaName(),
+                this.schemaRepository.getSchema(table.getSchemaName()),
                 table.getName(),
                 table.getAlias() != null ? table.getAlias().getName() : null
         );


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

This change introduces a stronger connection between the SQL AST nodes and the underlying database schema catalog. By linking the `From` and `Table` nodes directly to the `Schema` class from the catalog package, it becomes possible to represent the schema more accurately and improve query validation, analysis, and transformation processes.

# 💡 Solution (How?)

1. Modified the `From` class to hold a reference to the `Schema` object instead of just schema names as strings.
2. Updated the `Table` class to inherit from `From` and pass the `Schema` object, enabling a direct connection to the schema.
3. Refactored the `JSQLFromItemVisitor` to inject a `SchemaRepository` and use it to resolve schema objects from schema names.
4. Adjusted the `toString()` method in `Table` to utilize the schema's `getName()` method, ensuring proper schema reference in string representations.

This solution improves the accuracy and flexibility of the SQL parsing and AST manipulation by providing access to rich schema metadata.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
