### PR TITLE
Add Physical Statement Execution Planner

### DIFF
--- a/src/main/java/com/miljanilic/planner/LogicQueryExecutionPlanner.java
+++ b/src/main/java/com/miljanilic/planner/LogicQueryExecutionPlanner.java
@@ -2,7 +2,7 @@ package com.miljanilic.planner;
 
 import com.google.inject.Singleton;
 import com.miljanilic.planner.node.*;
-import com.miljanilic.sql.ast.ASTVisitorAdapter;
+import com.miljanilic.sql.ast.visitor.ASTVisitorAdapter;
 import com.miljanilic.sql.ast.clause.*;
 import com.miljanilic.sql.ast.expression.Expression;
 import com.miljanilic.sql.ast.expression.Function;

--- a/src/main/java/com/miljanilic/planner/PhysicalStatementExecutionPlanner.java
+++ b/src/main/java/com/miljanilic/planner/PhysicalStatementExecutionPlanner.java
@@ -1,0 +1,36 @@
+package com.miljanilic.planner;
+
+import com.google.inject.Inject;
+import com.miljanilic.planner.node.*;
+import com.miljanilic.sql.ast.statement.Statement;
+
+import java.util.List;
+
+public class PhysicalStatementExecutionPlanner implements ExecutionPlanner {
+    private final ExecutionPlanner planner;
+    private final List<ExecutionPlanVisitor<PlanNode, PlanNode>> executionPlanVisitorList;
+
+    @Inject
+    public PhysicalStatementExecutionPlanner(
+            ExecutionPlanner planner,
+            List<ExecutionPlanVisitor<PlanNode, PlanNode>> planners
+    ) {
+        this.planner = planner;
+        this.executionPlanVisitorList = planners;
+    }
+
+    @Override
+    public PlanNode plan(Statement statement) {
+        PlanNode finalPlan = planner.plan(statement);
+
+        if (executionPlanVisitorList.isEmpty()) {
+            throw new ExecutionPlannerException("Physical statement execution planner requires at least one rule configured.");
+        }
+
+        for (ExecutionPlanVisitor<PlanNode, PlanNode> visitor : executionPlanVisitorList) {
+            finalPlan = finalPlan.accept(visitor, null);
+        }
+
+        return finalPlan;
+    }
+}

--- a/src/main/java/com/miljanilic/planner/node/PlanNode.java
+++ b/src/main/java/com/miljanilic/planner/node/PlanNode.java
@@ -21,6 +21,10 @@ public abstract class PlanNode {
         children.add(child);
     }
 
+    public void addChildren(List<PlanNode> childrenList) {
+        children.addAll(childrenList);
+    }
+
     public List<PlanNode> getChildren() {
         return children;
     }

--- a/src/main/java/com/miljanilic/planner/node/RemoteFilterNode.java
+++ b/src/main/java/com/miljanilic/planner/node/RemoteFilterNode.java
@@ -1,0 +1,22 @@
+package com.miljanilic.planner.node;
+
+import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.sql.ast.expression.Expression;
+
+public class RemoteFilterNode extends FilterNode {
+    private final Schema schema;
+
+    public RemoteFilterNode(Expression condition, Schema schema) {
+        super(condition);
+        this.schema = schema;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    @Override
+    public String toString() {
+        return "Remote (" + schema.getName() + ") " + super.toString();
+    }
+}

--- a/src/main/java/com/miljanilic/planner/node/RemoteJoinNode.java
+++ b/src/main/java/com/miljanilic/planner/node/RemoteJoinNode.java
@@ -1,0 +1,23 @@
+package com.miljanilic.planner.node;
+
+import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.node.Join;
+
+public class RemoteJoinNode extends JoinNode {
+    private final Schema schema;
+
+    public RemoteJoinNode(PlanNode left, PlanNode right, Join.JoinType joinType, Expression condition, JoinAlgorithm algorithm, Schema schema) {
+        super(left, right, joinType, condition, algorithm);
+        this.schema = schema;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    @Override
+    public String toString() {
+        return "Remote (" + schema.getName() + ") " + super.toString();
+    }
+}

--- a/src/main/java/com/miljanilic/planner/node/RemoteProjectNode.java
+++ b/src/main/java/com/miljanilic/planner/node/RemoteProjectNode.java
@@ -1,0 +1,26 @@
+package com.miljanilic.planner.node;
+
+import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.node.Select;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RemoteProjectNode extends ProjectNode {
+    private final Schema schema;
+
+    public RemoteProjectNode(List<Select> selectList, Schema schema) {
+        super(selectList);
+        this.schema = schema;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    @Override
+    public String toString() {
+        return "Remote (" + schema.getName() + ") " + super.toString();
+    }
+}

--- a/src/main/java/com/miljanilic/planner/node/RemoteScanNode.java
+++ b/src/main/java/com/miljanilic/planner/node/RemoteScanNode.java
@@ -1,0 +1,24 @@
+package com.miljanilic.planner.node;
+
+import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.sql.ast.node.From;
+
+import java.util.List;
+
+public class RemoteScanNode extends ScanNode {
+    private final Schema schema;
+
+    public RemoteScanNode(From from, List<String> columns, Schema schema) {
+        super(from, columns);
+        this.schema = schema;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    @Override
+    public String toString() {
+        return "Remote (" + schema.getName() + ") " + super.toString();
+    }
+}

--- a/src/main/java/com/miljanilic/planner/rule/ExecutionPlannerRuleAdapter.java
+++ b/src/main/java/com/miljanilic/planner/rule/ExecutionPlannerRuleAdapter.java
@@ -1,0 +1,67 @@
+package com.miljanilic.planner.rule;
+
+import com.miljanilic.planner.ExecutionPlanVisitor;
+import com.miljanilic.planner.node.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExecutionPlannerRuleAdapter implements ExecutionPlanVisitor<PlanNode, PlanNode>  {
+    @Override
+    public PlanNode visit(ScanNode node, PlanNode context) {
+        node.setChildren(visitChildren(node.getChildren(), context));
+        return node;
+    }
+
+    @Override
+    public PlanNode visit(FilterNode node, PlanNode context) {
+        node.setChildren(visitChildren(node.getChildren(), context));
+        return node;
+    }
+
+    @Override
+    public PlanNode visit(JoinNode node, PlanNode context) {
+        node.setChildren(visitChildren(node.getChildren(), context));
+        return node;
+    }
+
+    @Override
+    public PlanNode visit(ProjectNode node, PlanNode context) {
+        node.setChildren(visitChildren(node.getChildren(), context));
+        return node;
+    }
+
+    @Override
+    public PlanNode visit(AggregateNode node, PlanNode context) {
+        node.setChildren(visitChildren(node.getChildren(), context));
+        return node;
+    }
+
+    @Override
+    public PlanNode visit(SortNode node, PlanNode context) {
+        node.setChildren(visitChildren(node.getChildren(), context));
+        return node;
+    }
+
+    @Override
+    public PlanNode visit(LimitNode node, PlanNode context) {
+        node.setChildren(visitChildren(node.getChildren(), context));
+        return node;
+    }
+
+    @Override
+    public PlanNode visit(HavingNode node, PlanNode context) {
+        node.setChildren(visitChildren(node.getChildren(), context));
+        return node;
+    }
+
+    protected List<PlanNode> visitChildren(List<PlanNode> children, PlanNode context) {
+        List<PlanNode> visitedChildren = new ArrayList<>();
+
+        for (PlanNode child : children) {
+            visitedChildren.add(child.accept(this, context));
+        }
+
+        return visitedChildren;
+    }
+}

--- a/src/main/java/com/miljanilic/planner/rule/JoinDecompositionExecutionPlannerRule.java
+++ b/src/main/java/com/miljanilic/planner/rule/JoinDecompositionExecutionPlannerRule.java
@@ -1,0 +1,30 @@
+package com.miljanilic.planner.rule;
+
+import com.miljanilic.planner.node.*;
+import java.util.List;
+
+public class JoinDecompositionExecutionPlannerRule extends ExecutionPlannerRuleAdapter {
+    @Override
+    public PlanNode visit(JoinNode node, PlanNode context) {
+        List<PlanNode> children = visitChildren(node.getChildren(), context);
+
+        if (children.getFirst() instanceof RemoteScanNode leftScan && children.getLast() instanceof RemoteScanNode rightScan) {
+            if (leftScan.getSchema().equals(rightScan.getSchema())) {
+                RemoteJoinNode remoteJoinNode = new RemoteJoinNode(
+                        node.getLeft(),
+                        node.getRight(),
+                        node.getJoinType(),
+                        node.getCondition(),
+                        node.getAlgorithm(),
+                        leftScan.getSchema()
+                );
+                remoteJoinNode.setChildren(children);
+
+                return remoteJoinNode;
+            }
+        }
+
+        node.setChildren(children);
+        return node;
+    }
+}

--- a/src/main/java/com/miljanilic/planner/rule/ProjectDecompositionExecutionPlannerRule.java
+++ b/src/main/java/com/miljanilic/planner/rule/ProjectDecompositionExecutionPlannerRule.java
@@ -1,0 +1,127 @@
+package com.miljanilic.planner.rule;
+
+import com.google.inject.Inject;
+import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.sql.ast.visitor.ASTColumnExtractingVisitor;
+import com.miljanilic.planner.ExecutionPlannerException;
+import com.miljanilic.planner.node.*;
+import com.miljanilic.sql.ast.expression.Column;
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.expression.Function;
+import com.miljanilic.sql.ast.node.*;
+
+import java.util.*;
+
+public class ProjectDecompositionExecutionPlannerRule extends ExecutionPlannerRuleAdapter {
+    private final ASTColumnExtractingVisitor columnListASTVisitor;
+
+    @Inject
+    public ProjectDecompositionExecutionPlannerRule(ASTColumnExtractingVisitor columnListASTVisitor) {
+        this.columnListASTVisitor = columnListASTVisitor;
+    }
+
+    @Override
+    public PlanNode visit(FilterNode node, PlanNode context) {
+        List<PlanNode> children = visitChildren(node.getChildren(), context);
+
+        List<Column> columnList = node.getCondition().accept(this.columnListASTVisitor, null);
+        node.setChildren(children);
+
+        return createRemoteProjectNodes(node, columnList);
+    }
+
+    @Override
+    public PlanNode visit(JoinNode node, PlanNode context) {
+        List<PlanNode> children = visitChildren(node.getChildren(), context);
+
+        List<Column> columnList = node.getCondition().accept(this.columnListASTVisitor, null);
+        node.setChildren(children);
+
+        return createRemoteProjectNodes(node, columnList);
+    }
+
+    @Override
+    public PlanNode visit(ProjectNode node, PlanNode context) {
+        List<PlanNode> children = visitChildren(node.getChildren(), context);
+        List<Column> columnList = new ArrayList<>();
+
+        for (Select select : node.getSelectList()) {
+            columnList.addAll(select.getExpression().accept(this.columnListASTVisitor, null));
+        }
+
+        node.setChildren(children);
+
+        return createRemoteProjectNodes(node, columnList);
+    }
+
+    @Override
+    public PlanNode visit(AggregateNode node, PlanNode context) {
+        List<PlanNode> children = visitChildren(node.getChildren(), context);
+        List<Column> columnList = new ArrayList<>();
+
+        for (Expression expr : node.getGroupByExpressions()) {
+            columnList.addAll(expr.accept(this.columnListASTVisitor, null));
+        }
+
+        for (Function func : node.getAggregateFunctions()) {
+            columnList.addAll(func.accept(this.columnListASTVisitor, null));
+        }
+
+        node.setChildren(children);
+
+        return createRemoteProjectNodes(node, columnList);
+    }
+
+    @Override
+    public PlanNode visit(SortNode node, PlanNode context) {
+        List<PlanNode> children = visitChildren(node.getChildren(), context);
+        List<Column> columnList = new ArrayList<>();
+
+        for (OrderBy orderBy : node.getOrderByList()) {
+            columnList.addAll(orderBy.getExpression().accept(this.columnListASTVisitor, null));
+        }
+
+        node.setChildren(children);
+
+        return createRemoteProjectNodes(node, columnList);
+    }
+
+    @Override
+    public PlanNode visit(HavingNode node, PlanNode context) {
+        List<PlanNode> children = visitChildren(node.getChildren(), context);
+
+        List<Column> columnList = node.getCondition().accept(this.columnListASTVisitor, null);
+        node.setChildren(children);
+
+        return createRemoteProjectNodes(node, columnList);
+    }
+
+    private PlanNode createRemoteProjectNodes(PlanNode originalNode, List<Column> columnList) {
+        Map<Schema, List<Select>> selectBySchema = new HashMap<>();
+
+        for (Column column : columnList) {
+            Schema schema = column.getFrom().getSchema();
+
+            if (schema == null) {
+                throw new ExecutionPlannerException("Schema not found.");
+            }
+
+            selectBySchema.computeIfAbsent(schema, k -> new ArrayList<>()).add(new Select(column, null));
+        }
+
+        PlanNode currentNode = originalNode;
+
+        for (Map.Entry<Schema, List<Select>> entry : selectBySchema.entrySet()) {
+            Schema schema = entry.getKey();
+            List<Select> selectList = entry.getValue();
+
+            if (!selectList.isEmpty()) {
+                RemoteProjectNode remoteProjectNode = new RemoteProjectNode(selectList, schema);
+                remoteProjectNode.addChild(currentNode);
+                currentNode = remoteProjectNode;
+            }
+        }
+
+        return currentNode;
+    }
+}

--- a/src/main/java/com/miljanilic/planner/rule/TableScanDecompositionExecutionPlannerRule.java
+++ b/src/main/java/com/miljanilic/planner/rule/TableScanDecompositionExecutionPlannerRule.java
@@ -1,0 +1,14 @@
+package com.miljanilic.planner.rule;
+
+import com.miljanilic.planner.node.*;
+
+public class TableScanDecompositionExecutionPlannerRule extends ExecutionPlannerRuleAdapter {
+    @Override
+    public PlanNode visit(ScanNode node, PlanNode context) {
+        return new RemoteScanNode(
+                node.getFrom(),
+                node.getColumns(),
+                node.getFrom().getSchema()
+        );
+    }
+}


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

This change introduces a more flexible execution planning system by decomposing query plans into remote and local execution nodes. This is necessary to support distributed query execution across different schemas.

# 💡 Solution (How?)

- Introduced new remote execution nodes (`RemoteScanNode`, `RemoteJoinNode`, `RemoteFilterNode`, etc.).
- Implemented `PhysicalStatementExecutionPlanner` and multiple decomposition rules (e.g., `JoinDecompositionExecutionPlannerRule`, `ProjectDecompositionExecutionPlannerRule`) to handle distributed planning.
- Refactored `ExecutionPlannerRuleAdapter` to streamline visiting and transforming plan nodes into remote operations.

This allows for distributed query execution by creating appropriate remote nodes based on schema and query structure.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
