### PR TITLE
Add Execution Plan Filters

### DIFF
--- a/src/main/java/com/miljanilic/planner/filter/ExecutionPlanAggregationNodeFilter.java
+++ b/src/main/java/com/miljanilic/planner/filter/ExecutionPlanAggregationNodeFilter.java
@@ -1,0 +1,111 @@
+package com.miljanilic.planner.filter;
+
+import com.miljanilic.planner.node.*;
+
+public class ExecutionPlanAggregationNodeFilter extends ExecutionPlanFilterAdapter implements ExecutionPlanFilter {
+
+    public PlanNode filter(PlanNode rootNode) {
+        return rootNode.accept(this, null);
+    }
+
+    @Override
+    public PlanNode visit(ScanNode node, PlanNode context) {
+        if (node instanceof RemoteScanNode) {
+            return node;
+        }
+
+        return context;
+    }
+
+    @Override
+    public PlanNode visit(FilterNode node, PlanNode context) {
+        if (!(node instanceof RemoteFilterNode)) {
+            PlanNode child = visitChildren(node.getChildren(), context);
+
+            if (child != null) {
+                FilterNode newNode = new FilterNode((node).getCondition());
+                newNode.addChild(child);
+                return newNode;
+            }
+        }
+
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(JoinNode node, PlanNode context) {
+        if (!(node instanceof RemoteJoinNode)) {
+            PlanNode left = node.getLeft().accept(this, context);
+            PlanNode right = node.getRight().accept(this, context);
+
+            if (left != null && right != null) {
+                return new JoinNode(left, right, node.getJoinType(), node.getCondition(), node.getAlgorithm());
+            }
+        }
+
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(ProjectNode node, PlanNode context) {
+        if (!(node instanceof RemoteProjectNode)) {
+            PlanNode child = visitChildren(node.getChildren(), context);
+
+            if (child != null) {
+                ProjectNode newNode = new ProjectNode(node.getSelectList());
+                newNode.addChild(child);
+
+                return newNode;
+            }
+        }
+
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(AggregateNode node, PlanNode context) {
+        PlanNode child = visitChildren(node.getChildren(), context);
+
+        AggregateNode newNode = new AggregateNode(
+                node.getGroupByExpressions(),
+                node.getAggregateFunctions()
+        );
+
+        newNode.addChild(child);
+
+        return newNode;
+    }
+
+    @Override
+    public PlanNode visit(HavingNode node, PlanNode context) {
+        PlanNode child = visitChildren(node.getChildren(), context);
+
+        HavingNode newNode = new HavingNode(node.getCondition());
+
+        newNode.addChild(child);
+
+        return newNode;
+    }
+
+    @Override
+    public PlanNode visit(SortNode node, PlanNode context) {
+        PlanNode child = visitChildren(node.getChildren(), context);
+
+        SortNode newNode = new SortNode(node.getOrderByList());
+
+        newNode.addChild(child);
+
+        return newNode;
+    }
+
+    @Override
+    public PlanNode visit(LimitNode node, PlanNode context) {
+        PlanNode child = visitChildren(node.getChildren(), context);
+
+        LimitNode newNode = new LimitNode(node.getLimit(), node.getOffset());
+
+        newNode.addChild(child);
+
+        return newNode;
+    }
+}

--- a/src/main/java/com/miljanilic/planner/filter/ExecutionPlanFilter.java
+++ b/src/main/java/com/miljanilic/planner/filter/ExecutionPlanFilter.java
@@ -1,0 +1,7 @@
+package com.miljanilic.planner.filter;
+
+import com.miljanilic.planner.node.PlanNode;
+
+public interface ExecutionPlanFilter {
+    PlanNode filter(PlanNode rootNode);
+}

--- a/src/main/java/com/miljanilic/planner/filter/ExecutionPlanFilterAdapter.java
+++ b/src/main/java/com/miljanilic/planner/filter/ExecutionPlanFilterAdapter.java
@@ -1,0 +1,59 @@
+package com.miljanilic.planner.filter;
+
+import com.miljanilic.planner.ExecutionPlanVisitor;
+import com.miljanilic.planner.node.*;
+
+import java.util.List;
+
+public class ExecutionPlanFilterAdapter implements ExecutionPlanVisitor<PlanNode, PlanNode> {
+
+    @Override
+    public PlanNode visit(ScanNode node, PlanNode context) {
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(FilterNode node, PlanNode context) {
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(JoinNode node, PlanNode context) {
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(ProjectNode node, PlanNode context) {
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(AggregateNode node, PlanNode context) {
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(SortNode node, PlanNode context) {
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(LimitNode node, PlanNode context) {
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(HavingNode node, PlanNode context) {
+        return visitChildren(node.getChildren(), context);
+    }
+
+    protected PlanNode visitChildren(List<PlanNode> children, PlanNode context) {
+        PlanNode result = context;
+
+        for (PlanNode child : children) {
+            result = child.accept(this, result);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/miljanilic/planner/filter/ExecutionPlanSchemaFilter.java
+++ b/src/main/java/com/miljanilic/planner/filter/ExecutionPlanSchemaFilter.java
@@ -1,0 +1,71 @@
+package com.miljanilic.planner.filter;
+
+import com.miljanilic.planner.node.*;
+import com.miljanilic.catalog.data.Schema;
+
+public class ExecutionPlanSchemaFilter extends ExecutionPlanFilterAdapter implements ExecutionPlanFilter {
+
+    private final Schema targetSchema;
+
+    public ExecutionPlanSchemaFilter(Schema targetSchema) {
+        this.targetSchema = targetSchema;
+    }
+
+    public PlanNode filter(PlanNode rootNode) {
+        return rootNode.accept(this, null);
+    }
+
+    @Override
+    public PlanNode visit(ScanNode node, PlanNode context) {
+        if (node instanceof RemoteScanNode && ((RemoteScanNode) node).getSchema().equals(targetSchema)) {
+            return node;
+        }
+
+        return context;
+    }
+
+    @Override
+    public PlanNode visit(FilterNode node, PlanNode context) {
+        if (node instanceof RemoteFilterNode && ((RemoteFilterNode) node).getSchema().equals(targetSchema)) {
+            PlanNode child = visitChildren(node.getChildren(), context);
+
+            if (child != null) {
+                RemoteFilterNode newNode = new RemoteFilterNode(((RemoteFilterNode) node).getCondition(), targetSchema);
+                newNode.addChild(child);
+                return newNode;
+            }
+        }
+
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(JoinNode node, PlanNode context) {
+        if (node instanceof RemoteJoinNode && ((RemoteJoinNode) node).getSchema().equals(targetSchema)) {
+            PlanNode left = node.getLeft().accept(this, context);
+            PlanNode right = node.getRight().accept(this, context);
+
+            if (left != null && right != null) {
+                return new RemoteJoinNode(left, right, node.getJoinType(), node.getCondition(), node.getAlgorithm(), targetSchema);
+            }
+        }
+
+        return visitChildren(node.getChildren(), context);
+    }
+
+    @Override
+    public PlanNode visit(ProjectNode node, PlanNode context) {
+        if (node instanceof RemoteProjectNode && ((RemoteProjectNode) node).getSchema().equals(targetSchema)) {
+            PlanNode child = visitChildren(node.getChildren(), context);
+
+            if (child != null) {
+                RemoteProjectNode newNode = new RemoteProjectNode(node.getSelectList(), targetSchema);
+                newNode.addChild(child);
+
+                return newNode;
+            }
+        }
+
+        return visitChildren(node.getChildren(), context);
+    }
+}

--- a/src/main/java/com/miljanilic/planner/filter/ExecutionPlanSchemaFilter.java
+++ b/src/main/java/com/miljanilic/planner/filter/ExecutionPlanSchemaFilter.java
@@ -1,7 +1,7 @@
 package com.miljanilic.planner.filter;
 
-import com.miljanilic.planner.node.*;
 import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.planner.node.*;
 
 public class ExecutionPlanSchemaFilter extends ExecutionPlanFilterAdapter implements ExecutionPlanFilter {
 


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

The change introduces a filtering mechanism to isolate specific nodes in an execution plan based on conditions such as schema or aggregation, enhancing the ability to refine and optimize execution plans.

# 💡 Solution (How?)

- Implemented `ExecutionPlanAggregationNodeFilter` and `ExecutionPlanSchemaFilter` to filter nodes based on aggregation logic or schema association.
- Created an adapter class, `ExecutionPlanFilterAdapter,` to simplify the implementation of custom filters.
- Added logic to handle different types of nodes like `RemoteFilterNode`, `RemoteJoinNode`, and `RemoteProjectNode` for schema-based filtering.

These filters allow for more targeted optimizations by focusing on specific plan nodes, improving performance in distributed and complex query execution scenarios.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
