### PR TITLE
Add Execution Plan Statement Converter

### DIFF
--- a/src/main/java/com/miljanilic/Application.java
+++ b/src/main/java/com/miljanilic/Application.java
@@ -1,25 +1,37 @@
 package com.miljanilic;
 
 import com.google.inject.Inject;
+import com.miljanilic.catalog.data.Schema;
 import com.miljanilic.planner.*;
+import com.miljanilic.planner.converter.ExecutionPlanStatementConverter;
+import com.miljanilic.planner.filter.ExecutionPlanAggregationNodeFilter;
+import com.miljanilic.planner.filter.ExecutionPlanFilter;
+import com.miljanilic.planner.filter.ExecutionPlanSchemaFilter;
 import com.miljanilic.planner.node.PlanNode;
+import com.miljanilic.planner.visitor.SchemaExtractingExecutionPlanVisitor;
+import com.miljanilic.sql.ast.statement.SelectStatement;
 import com.miljanilic.sql.ast.statement.Statement;
 import com.miljanilic.sql.parser.SQLParser;
 import com.miljanilic.sql.parser.SQLParserException;
 
+import java.util.HashSet;
 import java.util.Scanner;
+import java.util.Set;
 
 public class Application {
     private final SQLParser sqlParser;
     private final ExecutionPlanner executionPlanner;
+    private final ExecutionPlanStatementConverter executionPlanStatementConverter;
 
     @Inject
     public Application(
             SQLParser sqlParser,
-            ExecutionPlanner executionPlanner
+            ExecutionPlanner executionPlanner,
+            ExecutionPlanStatementConverter executionPlanStatementConverter
     ) {
         this.sqlParser = sqlParser;
         this.executionPlanner = executionPlanner;
+        this.executionPlanStatementConverter = executionPlanStatementConverter;
     }
 
     public void run() {
@@ -35,6 +47,43 @@ public class Application {
 
             PlanNode planRoot = executionPlanner.plan(statement);
             System.out.println(planRoot.explain());
+
+            System.out.println("----------------");
+
+            SelectStatement executionStatement = executionPlanStatementConverter.convert(planRoot);
+            System.out.println(executionStatement);
+
+            System.out.println("----------------");
+
+            ExecutionPlanVisitor<Void, Set<Schema>> schemaExtractor = new SchemaExtractingExecutionPlanVisitor();
+
+            HashSet<Schema> schemas = new HashSet<>();
+            planRoot.accept(schemaExtractor, schemas);
+
+            for (Schema schema : schemas) {
+                System.out.println(schema);
+                System.out.println("----------------");
+            }
+
+            for (Schema schema : schemas) {
+                ExecutionPlanFilter filter = new ExecutionPlanSchemaFilter(schema);
+
+                PlanNode schemaFilteredPlanRoot = filter.filter(planRoot);
+
+                SelectStatement schemaFilteredExecutionStatement = executionPlanStatementConverter.convert(schemaFilteredPlanRoot);
+                System.out.println(schemaFilteredExecutionStatement);
+
+                System.out.println("----------------");
+            }
+
+            ExecutionPlanFilter filter = new ExecutionPlanAggregationNodeFilter();
+
+            PlanNode schemaFilteredPlanRoot = filter.filter(planRoot);
+
+            SelectStatement schemaFilteredExecutionStatement = executionPlanStatementConverter.convert(schemaFilteredPlanRoot);
+            System.out.println(schemaFilteredExecutionStatement);
+
+            System.out.println("----------------");
         } catch (SQLParserException e) {
             System.out.println("Error parsing SQL: " + e.getMessage());
         }

--- a/src/main/java/com/miljanilic/module/PlannerModule.java
+++ b/src/main/java/com/miljanilic/module/PlannerModule.java
@@ -1,12 +1,52 @@
 package com.miljanilic.module;
 
 import com.google.inject.AbstractModule;
-import com.miljanilic.planner.ExecutionPlanner;
-import com.miljanilic.planner.LogicQueryExecutionPlanner;
+import com.google.inject.Provides;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.Multibinder;
+import com.miljanilic.planner.*;
+import com.miljanilic.planner.converter.ExecutionPlanStatementConverter;
+import com.miljanilic.planner.converter.ExecutionPlanVisitorStatementConverter;
+import com.miljanilic.planner.node.PlanNode;
+import com.miljanilic.planner.rule.JoinDecompositionExecutionPlannerRule;
+import com.miljanilic.planner.rule.ProjectDecompositionExecutionPlannerRule;
+import com.miljanilic.planner.rule.TableScanDecompositionExecutionPlannerRule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 public class PlannerModule extends AbstractModule {
     @Override
     protected void configure() {
-        bind(ExecutionPlanner.class).to(LogicQueryExecutionPlanner.class);
+        bind(ExecutionPlanner.class).to(PhysicalStatementExecutionPlanner.class);
+        bind(ExecutionPlanStatementConverter.class).to(ExecutionPlanVisitorStatementConverter.class);
+
+        Multibinder<ExecutionPlanVisitor<PlanNode, PlanNode>> plannerBinder = Multibinder.newSetBinder(
+                binder(),
+                new TypeLiteral<ExecutionPlanVisitor<PlanNode, PlanNode>>() {}
+        );
+
+        plannerBinder.addBinding().to(TableScanDecompositionExecutionPlannerRule.class);
+        plannerBinder.addBinding().to(JoinDecompositionExecutionPlannerRule.class);
+        plannerBinder.addBinding().to(ProjectDecompositionExecutionPlannerRule.class);
+    }
+
+    @Provides
+    public List<ExecutionPlanVisitor<PlanNode, PlanNode>> provideExecutionPlanVisitors(
+            Set<ExecutionPlanVisitor<PlanNode, PlanNode>> plannerSet
+    ) {
+        return new ArrayList<>(plannerSet);
+    }
+
+    @Provides
+    public PhysicalStatementExecutionPlanner providePhysicalStatementExecutionPlanner(
+            LogicQueryExecutionPlanner logicQueryExecutionPlanner,
+            List<ExecutionPlanVisitor<PlanNode, PlanNode>> planners
+    ) {
+        return new PhysicalStatementExecutionPlanner(
+                logicQueryExecutionPlanner,
+                planners
+        );
     }
 }

--- a/src/main/java/com/miljanilic/planner/converter/ExecutionPlanStatementConverter.java
+++ b/src/main/java/com/miljanilic/planner/converter/ExecutionPlanStatementConverter.java
@@ -1,0 +1,8 @@
+package com.miljanilic.planner.converter;
+
+import com.miljanilic.planner.node.PlanNode;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+
+public interface ExecutionPlanStatementConverter {
+    SelectStatement convert(PlanNode rootNode);
+}

--- a/src/main/java/com/miljanilic/planner/converter/ExecutionPlanVisitorStatementConverter.java
+++ b/src/main/java/com/miljanilic/planner/converter/ExecutionPlanVisitorStatementConverter.java
@@ -1,0 +1,129 @@
+package com.miljanilic.planner.converter;
+
+import com.miljanilic.planner.ExecutionPlanVisitor;
+import com.miljanilic.planner.node.*;
+import com.miljanilic.sql.ast.clause.*;
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.expression.Function;
+import com.miljanilic.sql.ast.expression.binary.AndOperator;
+import com.miljanilic.sql.ast.node.*;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+
+import java.util.*;
+
+public class ExecutionPlanVisitorStatementConverter implements ExecutionPlanStatementConverter, ExecutionPlanVisitor<SelectStatement, SelectStatement> {
+
+    @Override
+    public SelectStatement convert(PlanNode rootNode) {
+        return rootNode.accept(this, null);
+    }
+
+    @Override
+    public SelectStatement visit(ScanNode node, SelectStatement statement) {
+        if (statement == null) {
+            statement = new SelectStatement();
+        }
+        if (statement.getFromClause() == null) {
+            statement.setFromClause(new FromClause(node.getFrom()));
+        }
+        return statement;
+    }
+
+    @Override
+    public SelectStatement visit(FilterNode node, SelectStatement statement) {
+        SelectStatement result = visitChildren(node, statement);
+        Expression filterCondition = node.getCondition();
+
+        WhereClause whereClause = result.getWhereClause();
+        if (whereClause == null) {
+            result.setWhereClause(new WhereClause(filterCondition));
+        } else {
+            whereClause.setCondition(new AndOperator(whereClause.getCondition(), filterCondition));
+        }
+
+        return result;
+    }
+
+    @Override
+    public SelectStatement visit(JoinNode node, SelectStatement statement) {
+        SelectStatement leftStatement = node.getLeft().accept(this, statement);
+        SelectStatement rightStatement = node.getRight().accept(this, new SelectStatement());
+
+        Join join = new Join(node.getJoinType(), rightStatement.getFromClause().getFrom(), node.getCondition());
+
+        JoinClause joinClause = leftStatement.getJoinClause();
+        if (joinClause == null) {
+            joinClause = new JoinClause(new ArrayList<>());
+            leftStatement.setJoinClause(joinClause);
+        }
+        joinClause.addJoin(join);
+
+        return leftStatement;
+    }
+
+    @Override
+    public SelectStatement visit(ProjectNode node, SelectStatement statement) {
+        SelectStatement result = visitChildren(node, statement);
+        SelectClause selectClause = result.getSelectClause();
+        if (selectClause == null) {
+            selectClause = new SelectClause(new ArrayList<>());
+            result.setSelectClause(selectClause);
+        }
+        selectClause.getSelectList().addAll(node.getSelectList());
+        return result;
+    }
+
+    @Override
+    public SelectStatement visit(AggregateNode node, SelectStatement statement) {
+        SelectStatement result = visitChildren(node, statement);
+
+        if (!node.getGroupByExpressions().isEmpty()) {
+            GroupByClause groupByClause = new GroupByClause(new GroupBy(node.getGroupByExpressions().getFirst()));
+            result.setGroupByClause(groupByClause);
+        }
+
+        SelectClause selectClause = result.getSelectClause();
+        if (selectClause == null) {
+            selectClause = new SelectClause(new ArrayList<>());
+            result.setSelectClause(selectClause);
+        }
+        for (Function function : node.getAggregateFunctions()) {
+            selectClause.addSelect(new Select(function, null));
+        }
+
+        return result;
+    }
+
+    @Override
+    public SelectStatement visit(SortNode node, SelectStatement statement) {
+        SelectStatement result = visitChildren(node, statement);
+
+        if (!node.getOrderByList().isEmpty()) {
+            result.setOrderByClause(new OrderByClause(node.getOrderByList()));
+        }
+
+        return result;
+    }
+
+    @Override
+    public SelectStatement visit(LimitNode node, SelectStatement statement) {
+        SelectStatement result = visitChildren(node, statement);
+        result.setLimitClause(new LimitClause(node.getLimit(), node.getOffset()));
+        return result;
+    }
+
+    @Override
+    public SelectStatement visit(HavingNode node, SelectStatement statement) {
+        SelectStatement result = visitChildren(node, statement);
+        result.setHavingClause(new HavingClause(node.getCondition()));
+        return result;
+    }
+
+    private SelectStatement visitChildren(PlanNode node, SelectStatement statement) {
+        SelectStatement result = statement;
+        for (PlanNode child : node.getChildren()) {
+            result = child.accept(this, result);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/miljanilic/planner/visitor/SchemaExtractingExecutionPlanVisitor.java
+++ b/src/main/java/com/miljanilic/planner/visitor/SchemaExtractingExecutionPlanVisitor.java
@@ -1,0 +1,76 @@
+package com.miljanilic.planner.visitor;
+
+import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.planner.ExecutionPlanVisitor;
+import com.miljanilic.planner.node.*;
+
+import java.util.List;
+import java.util.Set;
+
+public class SchemaExtractingExecutionPlanVisitor implements ExecutionPlanVisitor<Void, Set<Schema>> {
+    @Override
+    public Void visit(ScanNode node, Set<Schema> schemas) {
+        if (node instanceof RemoteScanNode) {
+            schemas.add(((RemoteScanNode) node).getSchema());
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(FilterNode node, Set<Schema> schemas) {
+        if (node instanceof RemoteFilterNode) {
+            schemas.add(((RemoteFilterNode) node).getSchema());
+        }
+        visitChildren(node.getChildren(), schemas);
+        return null;
+    }
+
+    @Override
+    public Void visit(JoinNode node, Set<Schema> schemas) {
+        if (node instanceof RemoteJoinNode) {
+            schemas.add(((RemoteJoinNode) node).getSchema());
+        }
+        visitChildren(node.getChildren(), schemas);
+        return null;
+    }
+
+    @Override
+    public Void visit(ProjectNode node, Set<Schema> schemas) {
+        if (node instanceof RemoteProjectNode) {
+            schemas.add(((RemoteProjectNode) node).getSchema());
+        }
+        visitChildren(node.getChildren(), schemas);
+        return null;
+    }
+
+    @Override
+    public Void visit(AggregateNode node, Set<Schema> schemas) {
+        visitChildren(node.getChildren(), schemas);
+        return null;
+    }
+
+    @Override
+    public Void visit(SortNode node, Set<Schema> schemas) {
+        visitChildren(node.getChildren(), schemas);
+        return null;
+    }
+
+    @Override
+    public Void visit(LimitNode node, Set<Schema> schemas) {
+        visitChildren(node.getChildren(), schemas);
+        return null;
+    }
+
+    @Override
+    public Void visit(HavingNode node, Set<Schema> schemas) {
+        visitChildren(node.getChildren(), schemas);
+        return null;
+    }
+
+    private void visitChildren(List<PlanNode> children, Set<Schema> schemas) {
+        for (PlanNode child : children) {
+            child.accept(this, schemas);
+        }
+    }
+}


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

The change adds functionality to extract schemas from an execution plan and convert execution plans into SQL statements. This helps in distributing query execution and understanding how the plan interacts with schemas.

# 💡 Solution (How?)

- Introduced `ExecutionPlanStatementConverter` and `ExecutionPlanVisitorStatementConverter` to convert execution plans into `SelectStatement` objects.
- Implemented `SchemaExtractingExecutionPlanVisitor` to extract schemas used in the execution plan.
- Updated `Application` to display schema-specific and aggregation-filtered plans.
- Enhanced dependency injection in `PlannerModule` to bind new components and rules for planning and conversion.

These additions enable schema-based filtering and plan conversion, improving query execution and analysis.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
