### PR TITLE
Add SQL DeParser

### DIFF
--- a/src/main/java/com/miljanilic/Application.java
+++ b/src/main/java/com/miljanilic/Application.java
@@ -12,7 +12,8 @@ import com.miljanilic.planner.node.PlanNode;
 import com.miljanilic.planner.visitor.SchemaExtractingExecutionPlanVisitor;
 import com.miljanilic.sql.ast.statement.SelectStatement;
 import com.miljanilic.sql.ast.statement.Statement;
-import com.miljanilic.sql.parser.SQLParser;
+import com.miljanilic.sql.deparser.SqlDeParser;
+import com.miljanilic.sql.parser.SqlParser;
 import com.miljanilic.sql.parser.SQLParserException;
 
 import java.util.HashSet;
@@ -20,19 +21,22 @@ import java.util.Scanner;
 import java.util.Set;
 
 public class Application {
-    private final SQLParser sqlParser;
+    private final SqlParser sqlParser;
     private final ExecutionPlanner executionPlanner;
     private final ExecutionPlanStatementConverter executionPlanStatementConverter;
+    private final SqlDeParser sqlDeParser;
 
     @Inject
     public Application(
-            SQLParser sqlParser,
+            SqlParser sqlParser,
             ExecutionPlanner executionPlanner,
-            ExecutionPlanStatementConverter executionPlanStatementConverter
+            ExecutionPlanStatementConverter executionPlanStatementConverter,
+            SqlDeParser sqlDeParser
     ) {
         this.sqlParser = sqlParser;
         this.executionPlanner = executionPlanner;
         this.executionPlanStatementConverter = executionPlanStatementConverter;
+        this.sqlDeParser = sqlDeParser;
     }
 
     public void run() {
@@ -42,7 +46,8 @@ public class Application {
 
         try {
             Statement statement = sqlParser.parse(sql);
-            System.out.println(statement);
+            System.out.println("Parsed SQL: " + this.sqlDeParser.deparse(statement));
+
 
             System.out.println("----------------");
 
@@ -52,7 +57,7 @@ public class Application {
             System.out.println("----------------");
 
             SelectStatement executionStatement = executionPlanStatementConverter.convert(planRoot);
-            System.out.println(executionStatement);
+            System.out.println("Execution SQL: " + this.sqlDeParser.deparse(executionStatement));
 
             System.out.println("----------------");
 
@@ -72,7 +77,7 @@ public class Application {
                 PlanNode schemaFilteredPlanRoot = filter.filter(planRoot);
 
                 SelectStatement schemaFilteredExecutionStatement = executionPlanStatementConverter.convert(schemaFilteredPlanRoot);
-                System.out.println(schemaFilteredExecutionStatement);
+                System.out.println("Schema Filtered SQL (" + schema.getName() + "): " + this.sqlDeParser.deparse(schemaFilteredExecutionStatement));
 
                 System.out.println("----------------");
             }
@@ -82,7 +87,8 @@ public class Application {
             PlanNode schemaFilteredPlanRoot = filter.filter(planRoot);
 
             SelectStatement schemaFilteredExecutionStatement = executionPlanStatementConverter.convert(schemaFilteredPlanRoot);
-            System.out.println(schemaFilteredExecutionStatement);
+
+            System.out.println("Aggregation SQL: " + this.sqlDeParser.deparse(schemaFilteredExecutionStatement));
 
             System.out.println("----------------");
         } catch (SQLParserException e) {

--- a/src/main/java/com/miljanilic/module/SQLModule.java
+++ b/src/main/java/com/miljanilic/module/SQLModule.java
@@ -8,8 +8,10 @@ import com.miljanilic.sql.ast.node.GroupBy;
 import com.miljanilic.sql.ast.node.OrderBy;
 import com.miljanilic.sql.ast.node.Select;
 import com.miljanilic.sql.ast.statement.Statement;
+import com.miljanilic.sql.deparser.JSqlDeParser;
+import com.miljanilic.sql.deparser.SqlDeParser;
 import com.miljanilic.sql.parser.JSQLParser;
-import com.miljanilic.sql.parser.SQLParser;
+import com.miljanilic.sql.parser.SqlParser;
 import com.miljanilic.sql.parser.visitor.*;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.statement.select.*;
@@ -17,7 +19,8 @@ import net.sf.jsqlparser.statement.select.*;
 public class SQLModule extends AbstractModule {
     @Override
     protected void configure() {
-        bind(SQLParser.class).to(JSQLParser.class);
+        bind(SqlParser.class).to(JSQLParser.class);
+        bind(SqlDeParser.class).to(JSqlDeParser.class);
 
         bind(new TypeLiteral<SelectVisitor<Statement>>() {}).to(JSQLSelectVisitor.class);
         bind(new TypeLiteral<SelectItemVisitor<Select>>() {}).to(JSQLSelectItemVisitor.class);

--- a/src/main/java/com/miljanilic/sql/deparser/JSqlDeParser.java
+++ b/src/main/java/com/miljanilic/sql/deparser/JSqlDeParser.java
@@ -1,0 +1,37 @@
+package com.miljanilic.sql.deparser;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+import com.miljanilic.sql.ast.statement.Statement;
+import com.miljanilic.sql.deparser.visitor.AstToJSqlSelectStatementVisitor;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+
+@Singleton
+public class JSqlDeParser implements SqlDeParser {
+    private final AstToJSqlSelectStatementVisitor selectStatementVisitor;
+
+    @Inject
+    public JSqlDeParser(AstToJSqlSelectStatementVisitor selectVisitor) {
+        this.selectStatementVisitor = selectVisitor;
+    }
+
+    public String deparse(Statement statement) {
+        StringBuilder builder = new StringBuilder();
+        StatementDeParser deParser = new StatementDeParser(builder);
+
+
+        if (statement instanceof SelectStatement) {
+            deParser.visit(visit((SelectStatement) statement));
+
+            return builder.toString();
+        }
+
+        throw new UnsupportedOperationException("Only SELECT statements are supported.");
+    }
+
+    public PlainSelect visit(SelectStatement select) {
+        return select.accept(selectStatementVisitor, null);
+    }
+}

--- a/src/main/java/com/miljanilic/sql/deparser/SqlDeParser.java
+++ b/src/main/java/com/miljanilic/sql/deparser/SqlDeParser.java
@@ -1,0 +1,7 @@
+package com.miljanilic.sql.deparser;
+
+import com.miljanilic.sql.ast.statement.Statement;
+
+public interface SqlDeParser {
+    String deparse(Statement statement);
+}

--- a/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlExpressionVisitor.java
+++ b/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlExpressionVisitor.java
@@ -1,0 +1,179 @@
+package com.miljanilic.sql.deparser.visitor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.sql.ast.expression.*;
+import com.miljanilic.sql.ast.expression.Function;
+import com.miljanilic.sql.ast.expression.binary.*;
+import com.miljanilic.sql.ast.visitor.ASTVisitorAdapter;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
+import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.relational.MinorThan;
+import net.sf.jsqlparser.expression.operators.relational.MinorThanEquals;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.select.FromItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class AstToJSqlExpressionVisitor extends ASTVisitorAdapter<Expression, Void> {
+    private final AstToJSqlFromItemVisitor fromItemVisitor;
+
+    @Inject
+    public AstToJSqlExpressionVisitor(AstToJSqlFromItemVisitor fromItemVisitor) {
+        this.fromItemVisitor = fromItemVisitor;
+    }
+
+    @Override
+    public Expression visit(com.miljanilic.sql.ast.expression.Column column, Void context) {
+        FromItem jsqlFromItem = column.getFrom().accept(fromItemVisitor, null);
+        Table jsqlTable = null;
+
+        if (jsqlFromItem instanceof Table) {
+            jsqlTable = (Table) jsqlFromItem;
+        }
+
+        return new Column(
+                jsqlTable,
+                column.getName()
+        );
+    }
+
+    @Override
+    public Expression visit(Function function, Void context) {
+        net.sf.jsqlparser.expression.Function jsqlFunction = new net.sf.jsqlparser.expression.Function();
+
+        jsqlFunction.setName(function.getFunctionName());
+        jsqlFunction.setParameters(function.getArguments().accept(this, context));
+
+        return jsqlFunction;
+    }
+
+    @Override
+    public Expression visit(LongValue longValue, Void context) {
+        return new net.sf.jsqlparser.expression.LongValue(longValue.getValue());
+    }
+
+    @Override
+    public Expression visit(StringValue stringValue, Void context) {
+        return new net.sf.jsqlparser.expression.StringValue(stringValue.getValue());
+    }
+
+    @Override
+    public Expression visit(EqualsTo equalsTo, Void context) {
+        return new net.sf.jsqlparser.expression.operators.relational.EqualsTo(
+                equalsTo.getLeft().accept(this, context),
+                equalsTo.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(NotEqualsTo notEqualsTo, Void context) {
+        return new net.sf.jsqlparser.expression.operators.relational.NotEqualsTo(
+                notEqualsTo.getLeft().accept(this, context),
+                notEqualsTo.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(GreaterThan greaterThan, Void context) {
+        return new net.sf.jsqlparser.expression.operators.relational.GreaterThan(
+                greaterThan.getLeft().accept(this, context),
+                greaterThan.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(GreaterThanEquals greaterThanEquals, Void context) {
+        return new net.sf.jsqlparser.expression.operators.relational.GreaterThanEquals(
+                greaterThanEquals.getLeft().accept(this, context),
+                greaterThanEquals.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(LessThan lessThan, Void context) {
+        return new MinorThan(
+                lessThan.getLeft().accept(this, context),
+                lessThan.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(LessThanEquals lessThanEquals, Void context) {
+        return new MinorThanEquals(
+                lessThanEquals.getLeft().accept(this, context),
+                lessThanEquals.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(AndOperator andOperator, Void context) {
+        return new AndExpression(
+                andOperator.getLeft().accept(this, context),
+                andOperator.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(OrOperator orOperator, Void context) {
+        return new OrExpression(
+                orOperator.getLeft().accept(this, context),
+                orOperator.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(Addition addition, Void context) {
+        return new net.sf.jsqlparser.expression.operators.arithmetic.Addition(
+                addition.getLeft().accept(this, context),
+                addition.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(Subtraction subtraction, Void context) {
+        return new net.sf.jsqlparser.expression.operators.arithmetic.Subtraction(
+                subtraction.getLeft().accept(this, context),
+                subtraction.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(Multiplication multiplication, Void context) {
+        return new net.sf.jsqlparser.expression.operators.arithmetic.Multiplication(
+                multiplication.getLeft().accept(this, context),
+                multiplication.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(Division division, Void context) {
+        return new net.sf.jsqlparser.expression.operators.arithmetic.Division(
+                division.getLeft().accept(this, context),
+                division.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(Modulo modulo, Void context) {
+        return new net.sf.jsqlparser.expression.operators.arithmetic.Modulo(
+                modulo.getLeft().accept(this, context),
+                modulo.getRight().accept(this, context)
+        );
+    }
+
+    @Override
+    public Expression visit(ExpressionList expressionList, Void context) {
+        List<Expression> expressions = new ArrayList<>();
+
+        for (com.miljanilic.sql.ast.expression.Expression expression : expressionList.getExpressions()) {
+            expressions.add(expression.accept(this, context));
+        }
+
+        return new net.sf.jsqlparser.expression.operators.relational.ExpressionList<>(expressions);
+    }
+}

--- a/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlFromItemVisitor.java
+++ b/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlFromItemVisitor.java
@@ -1,0 +1,23 @@
+package com.miljanilic.sql.deparser.visitor;
+
+import com.google.inject.Singleton;
+import com.miljanilic.sql.ast.node.Table;
+import com.miljanilic.sql.ast.visitor.ASTVisitorAdapter;
+import net.sf.jsqlparser.statement.select.FromItem;
+
+@Singleton
+public class AstToJSqlFromItemVisitor extends ASTVisitorAdapter<FromItem, Void> {
+    @Override
+    public FromItem visit(Table table, Void context) {
+        net.sf.jsqlparser.schema.Table jsqlTable = new net.sf.jsqlparser.schema.Table();
+
+        jsqlTable.setSchemaName(table.getSchema().getName());
+        jsqlTable.setName(table.getName());
+
+        if (table.getAlias() != null) {
+            jsqlTable.setAlias(new net.sf.jsqlparser.expression.Alias(table.getAlias()));
+        }
+
+        return jsqlTable;
+    }
+}

--- a/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlGroupByVisitor.java
+++ b/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlGroupByVisitor.java
@@ -1,0 +1,31 @@
+package com.miljanilic.sql.deparser.visitor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.sql.ast.node.GroupBy;
+import com.miljanilic.sql.ast.visitor.ASTVisitorAdapter;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.statement.select.GroupByElement;
+
+@Singleton
+public class AstToJSqlGroupByVisitor extends ASTVisitorAdapter<GroupByElement, Void> {
+    private final AstToJSqlExpressionVisitor expressionVisitor;
+
+    @Inject
+    public AstToJSqlGroupByVisitor(AstToJSqlExpressionVisitor expressionVisitor) {
+        this.expressionVisitor = expressionVisitor;
+    }
+
+    @Override
+    public GroupByElement visit(GroupBy groupBy, Void context) {
+        GroupByElement jsqlGroupByElement = new GroupByElement();
+
+        ExpressionList<?> expressionList = new ExpressionList<>(
+                groupBy.getExpression().accept(expressionVisitor, null)
+        );
+
+        jsqlGroupByElement.addGroupByExpressions(expressionList);
+
+        return jsqlGroupByElement;
+    }
+}

--- a/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlJoinVisitor.java
+++ b/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlJoinVisitor.java
@@ -1,0 +1,52 @@
+package com.miljanilic.sql.deparser.visitor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.sql.ast.visitor.ASTVisitorAdapter;
+import net.sf.jsqlparser.statement.select.Join;
+
+@Singleton
+public class AstToJSqlJoinVisitor extends ASTVisitorAdapter<Join, Void> {
+    private final AstToJSqlExpressionVisitor expressionVisitor;
+    private final AstToJSqlFromItemVisitor fromItemVisitor;
+
+    @Inject
+    public AstToJSqlJoinVisitor(AstToJSqlExpressionVisitor expressionVisitor, AstToJSqlFromItemVisitor fromItemVisitor) {
+        this.expressionVisitor = expressionVisitor;
+        this.fromItemVisitor = fromItemVisitor;
+    }
+
+    @Override
+    public Join visit(com.miljanilic.sql.ast.node.Join join, Void context) {
+        Join jsqlJoin = new Join();
+
+        jsqlJoin.setRightItem(join.getFrom().accept(fromItemVisitor, null));
+
+        // Set the join type
+        switch (join.getJoinType()) {
+            case INNER:
+                jsqlJoin.setInner(true);
+                break;
+            case LEFT:
+                jsqlJoin.setLeft(true);
+                break;
+            case RIGHT:
+                jsqlJoin.setRight(true);
+                break;
+            case FULL:
+                jsqlJoin.setFull(true);
+                break;
+            case CROSS:
+                jsqlJoin.setCross(true);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported join type: " + join.getJoinType());
+        }
+
+        if (join.getConditions() != null) {
+            jsqlJoin.addOnExpression(join.getConditions().accept(expressionVisitor, null));
+        }
+
+        return jsqlJoin;
+    }
+}

--- a/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlOrderByVisitor.java
+++ b/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlOrderByVisitor.java
@@ -1,0 +1,28 @@
+package com.miljanilic.sql.deparser.visitor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.sql.ast.node.OrderBy;
+import com.miljanilic.sql.ast.visitor.ASTVisitorAdapter;
+import net.sf.jsqlparser.statement.select.OrderByElement;
+
+@Singleton
+public class AstToJSqlOrderByVisitor extends ASTVisitorAdapter<OrderByElement, Void> {
+
+    private final AstToJSqlExpressionVisitor expressionVisitor;
+
+    @Inject
+    public AstToJSqlOrderByVisitor(AstToJSqlExpressionVisitor expressionVisitor) {
+        this.expressionVisitor = expressionVisitor;
+    }
+
+    @Override
+    public OrderByElement visit(OrderBy orderBy, Void context) {
+        OrderByElement element = new OrderByElement();
+
+        element.setExpression(orderBy.getExpression().accept(expressionVisitor, null));
+        element.setAsc(orderBy.isAscending());
+
+        return element;
+    }
+}

--- a/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlSelectStatementVisitor.java
+++ b/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlSelectStatementVisitor.java
@@ -1,0 +1,96 @@
+package com.miljanilic.sql.deparser.visitor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.sql.ast.node.OrderBy;
+import com.miljanilic.sql.ast.node.Select;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+import com.miljanilic.sql.ast.visitor.ASTVisitorAdapter;
+import net.sf.jsqlparser.statement.select.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class AstToJSqlSelectStatementVisitor extends ASTVisitorAdapter<PlainSelect, Void> {
+    private final AstToJSqlSelectVisitor selectVisitor;
+    private final AstToJSqlFromItemVisitor fromItemVisitor;
+    private final AstToJSqlJoinVisitor joinVisitor;
+    private final AstToJSqlExpressionVisitor expressionVisitor;
+    private final AstToJSqlOrderByVisitor orderByVisitor;
+    private final AstToJSqlGroupByVisitor groupByVisitor;
+
+    @Inject
+    public AstToJSqlSelectStatementVisitor(
+            AstToJSqlSelectVisitor selectVisitor,
+            AstToJSqlFromItemVisitor fromItemVisitor,
+            AstToJSqlJoinVisitor joinVisitor,
+            AstToJSqlExpressionVisitor expressionVisitor,
+            AstToJSqlOrderByVisitor orderByVisitor,
+            AstToJSqlGroupByVisitor groupByVisitor
+    ) {
+        this.selectVisitor = selectVisitor;
+        this.fromItemVisitor = fromItemVisitor;
+        this.joinVisitor = joinVisitor;
+        this.expressionVisitor = expressionVisitor;
+        this.orderByVisitor = orderByVisitor;
+        this.groupByVisitor = groupByVisitor;
+    }
+
+    @Override
+    public PlainSelect visit(SelectStatement selectStatement, Void context) {
+        PlainSelect plainSelect = new PlainSelect();
+
+        for (Select select : selectStatement.getSelectClause().getSelectList()) {
+            plainSelect.addSelectItem(select.accept(selectVisitor, null));
+        }
+
+        plainSelect.setFromItem(selectStatement.getFromClause().getFrom().accept(fromItemVisitor, null));
+
+        if (selectStatement.getJoinClause() != null) {
+            List<Join> joins = new ArrayList<>();
+
+            for (com.miljanilic.sql.ast.node.Join join : selectStatement.getJoinClause().getJoinList()) {
+                joins.add(join.accept(joinVisitor, null));
+            }
+
+            plainSelect.setJoins(joins);
+        }
+
+        if (selectStatement.getWhereClause() != null) {
+            plainSelect.setWhere(selectStatement.getWhereClause().getCondition().accept(expressionVisitor, null));
+        }
+
+        if (selectStatement.getGroupByClause() != null) {
+            plainSelect.setGroupByElement(selectStatement.getGroupByClause().getGroupBy().accept(groupByVisitor, null));
+        }
+
+        if (selectStatement.getHavingClause() != null) {
+            plainSelect.setHaving(selectStatement.getHavingClause().getCondition().accept(expressionVisitor, null));
+        }
+
+        if (selectStatement.getOrderByClause() != null) {
+            List<OrderByElement> orderByElements = new ArrayList<>();
+
+            for (OrderBy orderBy : selectStatement.getOrderByClause().getOrderByList()) {
+                orderByElements.add(orderBy.accept(orderByVisitor, null));
+            }
+
+            plainSelect.setOrderByElements(orderByElements);
+        }
+
+        if (selectStatement.getLimitClause() != null) {
+            Limit limit = new Limit();
+
+            limit.setRowCount(selectStatement.getLimitClause().getLimit().accept(expressionVisitor, null));
+
+            if (selectStatement.getLimitClause().getOffset() != null) {
+                limit.setOffset(selectStatement.getLimitClause().getOffset().accept(expressionVisitor, null));
+            }
+
+            plainSelect.setLimit(limit);
+        }
+
+        return plainSelect;
+    }
+}

--- a/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlSelectVisitor.java
+++ b/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlSelectVisitor.java
@@ -1,0 +1,22 @@
+package com.miljanilic.sql.deparser.visitor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.sql.ast.node.Select;
+import com.miljanilic.sql.ast.visitor.ASTVisitorAdapter;
+import net.sf.jsqlparser.expression.Expression;
+
+@Singleton
+public class AstToJSqlSelectVisitor extends ASTVisitorAdapter<Expression, Void> {
+    private final AstToJSqlExpressionVisitor expressionVisitor;
+
+    @Inject
+    public AstToJSqlSelectVisitor(AstToJSqlExpressionVisitor expressionVisitor) {
+        this.expressionVisitor = expressionVisitor;
+    }
+
+    @Override
+    public Expression visit(Select table, Void context) {
+        return table.getExpression().accept(expressionVisitor, context);
+    }
+}

--- a/src/main/java/com/miljanilic/sql/parser/JSQLParser.java
+++ b/src/main/java/com/miljanilic/sql/parser/JSQLParser.java
@@ -8,7 +8,7 @@ import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.select.SelectVisitor;
 
 @Singleton
-public class JSQLParser implements SQLParser {
+public class JSQLParser implements SqlParser {
     private final SelectVisitor<Statement> selectVisitor;
 
     @Inject

--- a/src/main/java/com/miljanilic/sql/parser/SQLParser.java
+++ b/src/main/java/com/miljanilic/sql/parser/SQLParser.java
@@ -1,7 +1,0 @@
-package com.miljanilic.sql.parser;
-
-import com.miljanilic.sql.ast.statement.Statement;
-
-public interface SQLParser {
-    Statement parse(String sql);
-}

--- a/src/main/java/com/miljanilic/sql/parser/SqlParser.java
+++ b/src/main/java/com/miljanilic/sql/parser/SqlParser.java
@@ -1,0 +1,7 @@
+package com.miljanilic.sql.parser;
+
+import com.miljanilic.sql.ast.statement.Statement;
+
+public interface SqlParser {
+    Statement parse(String sql);
+}


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

Introduced a new SQL deparser to convert SQL AST back into SQL strings. Renamed `SQLParser` to `SqlParser` for consistency with naming conventions. Improved output by printing parsed and generated SQL in a more readable format.

# 💡 Solution (How?)

Added a `SqlDeParser` interface and its implementation `JSqlDeParser` to handle SQL deparsing. Integrated `SqlDeParser` into `Application` to print human-readable SQL strings during execution. Refactored module bindings to register `SqlParser` and `SqlDeParser` with appropriate implementations.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
