### PR TITLE
Add `equals` to AST Nodes

### DIFF
--- a/src/main/java/com/miljanilic/sql/ast/expression/Column.java
+++ b/src/main/java/com/miljanilic/sql/ast/expression/Column.java
@@ -3,6 +3,8 @@ package com.miljanilic.sql.ast.expression;
 import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.node.From;
 
+import java.util.Objects;
+
 public class Column extends Expression {
     private final String name;
     private final From from;
@@ -23,6 +25,18 @@ public class Column extends Expression {
     @Override
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {
         return visitor.visit(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Column column)) return false;
+        return Objects.equals(name, column.name) && Objects.equals(from, column.from);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, from);
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/expression/ExpressionList.java
+++ b/src/main/java/com/miljanilic/sql/ast/expression/ExpressionList.java
@@ -3,6 +3,7 @@ package com.miljanilic.sql.ast.expression;
 import com.miljanilic.sql.ast.ASTVisitor;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ExpressionList extends Expression {
@@ -19,6 +20,18 @@ public class ExpressionList extends Expression {
     @Override
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {
         return visitor.visit(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ExpressionList that)) return false;
+        return Objects.equals(expressions, that.expressions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(expressions);
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/expression/Function.java
+++ b/src/main/java/com/miljanilic/sql/ast/expression/Function.java
@@ -2,6 +2,8 @@ package com.miljanilic.sql.ast.expression;
 
 import com.miljanilic.sql.ast.ASTVisitor;
 
+import java.util.Objects;
+
 public class Function extends Expression {
     private final String functionName;
     private final Expression arguments;
@@ -22,6 +24,18 @@ public class Function extends Expression {
     @Override
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {
         return visitor.visit(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Function function)) return false;
+        return Objects.equals(functionName, function.functionName) && Objects.equals(arguments, function.arguments);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(functionName, arguments);
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/expression/LongValue.java
+++ b/src/main/java/com/miljanilic/sql/ast/expression/LongValue.java
@@ -2,6 +2,8 @@ package com.miljanilic.sql.ast.expression;
 
 import com.miljanilic.sql.ast.ASTVisitor;
 
+import java.util.Objects;
+
 public class LongValue extends Expression {
     private final Long value;
 
@@ -15,6 +17,18 @@ public class LongValue extends Expression {
 
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {
         return visitor.visit(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LongValue longValue)) return false;
+        return Objects.equals(value, longValue.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/expression/StringValue.java
+++ b/src/main/java/com/miljanilic/sql/ast/expression/StringValue.java
@@ -2,6 +2,8 @@ package com.miljanilic.sql.ast.expression;
 
 import com.miljanilic.sql.ast.ASTVisitor;
 
+import java.util.Objects;
+
 public class StringValue extends Expression {
     public final String value;
 
@@ -15,6 +17,18 @@ public class StringValue extends Expression {
 
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {
         return visitor.visit(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof StringValue that)) return false;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/expression/binary/Binary.java
+++ b/src/main/java/com/miljanilic/sql/ast/expression/binary/Binary.java
@@ -3,6 +3,8 @@ package com.miljanilic.sql.ast.expression.binary;
 import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.expression.Expression;
 
+import java.util.Objects;
+
 public abstract class Binary extends Expression {
     private final Expression left;
     private final String operator;
@@ -28,6 +30,18 @@ public abstract class Binary extends Expression {
 
     @Override
     public abstract <T, S> T accept(ASTVisitor<T, S> visitor, S context);
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Binary binary)) return false;
+        return Objects.equals(left, binary.left) && Objects.equals(operator, binary.operator) && Objects.equals(right, binary.right);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, operator, right);
+    }
 
     public String toString() {
         return "(" + left + " " + operator + " " + right + ")";

--- a/src/main/java/com/miljanilic/sql/ast/node/From.java
+++ b/src/main/java/com/miljanilic/sql/ast/node/From.java
@@ -16,10 +16,6 @@ public abstract class From extends Node {
         return schema;
     }
 
-    public Table getSchemaTable() {
-        return schemaTable;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/miljanilic/sql/ast/node/From.java
+++ b/src/main/java/com/miljanilic/sql/ast/node/From.java
@@ -3,6 +3,8 @@ package com.miljanilic.sql.ast.node;
 import com.miljanilic.catalog.data.Schema;
 import com.miljanilic.sql.ast.ASTVisitor;
 
+import java.util.Objects;
+
 public abstract class From extends Node {
     protected final Schema schema;
 
@@ -12,6 +14,22 @@ public abstract class From extends Node {
 
     public Schema getSchema() {
         return schema;
+    }
+
+    public Table getSchemaTable() {
+        return schemaTable;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof From from)) return false;
+        return Objects.equals(schema, from.schema) && Objects.equals(schemaTable, from.schemaTable);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(schema);
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/node/Select.java
+++ b/src/main/java/com/miljanilic/sql/ast/node/Select.java
@@ -3,6 +3,8 @@ package com.miljanilic.sql.ast.node;
 import com.miljanilic.sql.ast.ASTVisitor;
 import com.miljanilic.sql.ast.expression.Expression;
 
+import java.util.Objects;
+
 public class Select extends Node {
     private final Expression expression;
     private final String alias;
@@ -22,6 +24,18 @@ public class Select extends Node {
 
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {
         return visitor.visit(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Select select)) return false;
+        return Objects.equals(expression, select.expression) && Objects.equals(alias, select.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expression, alias);
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/node/Table.java
+++ b/src/main/java/com/miljanilic/sql/ast/node/Table.java
@@ -3,6 +3,8 @@ package com.miljanilic.sql.ast.node;
 import com.miljanilic.catalog.data.Schema;
 import com.miljanilic.sql.ast.ASTVisitor;
 
+import java.util.Objects;
+
 public class Table extends From {
     private final String name;
     private final String alias;
@@ -24,6 +26,19 @@ public class Table extends From {
     @Override
     public <T, S> T accept(ASTVisitor<T, S> visitor, S context) {
         return visitor.visit(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Table table)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(name, table.name) && Objects.equals(alias, table.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name, alias);
     }
 
     public String toString() {


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

Enhance object comparison and improve code consistency.

# 💡 Solution (How?)

Added `equals()` and `hashCode()` methods to AST node classes.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [x] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
