### PR TITLE
Add Table Schema to From Node

### DIFF
--- a/src/main/java/com/miljanilic/sql/ast/node/From.java
+++ b/src/main/java/com/miljanilic/sql/ast/node/From.java
@@ -1,19 +1,26 @@
 package com.miljanilic.sql.ast.node;
 
 import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.catalog.data.Table;
 import com.miljanilic.sql.ast.ASTVisitor;
 
 import java.util.Objects;
 
 public abstract class From extends Node {
     protected final Schema schema;
+    protected final Table schemaTable;
 
-    protected From(Schema schema) {
+    protected From(Schema schema, Table schemaTable) {
         this.schema = schema;
+        this.schemaTable = schemaTable;
     }
 
     public Schema getSchema() {
         return schema;
+    }
+
+    public Table getSchemaTable() {
+        return schemaTable;
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/node/Table.java
+++ b/src/main/java/com/miljanilic/sql/ast/node/Table.java
@@ -9,8 +9,8 @@ public class Table extends From {
     private final String name;
     private final String alias;
 
-    public Table(Schema schema, String name, String alias) {
-        super(schema);
+    public Table(Schema schema, com.miljanilic.catalog.data.Table table, String name, String alias) {
+        super(schema, table);
         this.name = name;
         this.alias = alias;
     }

--- a/src/main/java/com/miljanilic/sql/parser/visitor/JSQLFromItemVisitor.java
+++ b/src/main/java/com/miljanilic/sql/parser/visitor/JSQLFromItemVisitor.java
@@ -20,6 +20,7 @@ public class JSQLFromItemVisitor extends FromItemVisitorAdapter<From> {
     public <S> From visit(net.sf.jsqlparser.schema.Table table, S context) {
         return new Table(
                 this.schemaRepository.getSchema(table.getSchemaName()),
+                this.schemaRepository.getSchemaTable(table.getSchemaName(), table.getName()),
                 table.getName(),
                 table.getAlias() != null ? table.getAlias().getName() : null
         );


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

Enhance `From` and `Table` classes with schema table information.

# 💡 Solution (How?)

Updated `From` class to include `schemaTable`. Modified `Table` constructor and `JSQLFromItemVisitor` to accommodate this change.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [x] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
