### PR TITLE
Ensure `SelectItem` Not Duplicated When Converting From ProjectNode

### DIFF
--- a/src/main/java/com/miljanilic/planner/converter/ExecutionPlanVisitorStatementConverter.java
+++ b/src/main/java/com/miljanilic/planner/converter/ExecutionPlanVisitorStatementConverter.java
@@ -67,11 +67,20 @@ public class ExecutionPlanVisitorStatementConverter implements ExecutionPlanStat
     public SelectStatement visit(ProjectNode node, SelectStatement statement) {
         SelectStatement result = visitChildren(node, statement);
         SelectClause selectClause = result.getSelectClause();
+
         if (selectClause == null) {
             selectClause = new SelectClause(new ArrayList<>());
             result.setSelectClause(selectClause);
         }
-        selectClause.getSelectList().addAll(node.getSelectList());
+
+        for (Select select : node.getSelectList()) {
+            if (selectClause.getSelectList().contains(select)) {
+                continue;
+            }
+
+            selectClause.addSelect(select);
+        }
+
         return result;
     }
 


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

Prevent duplicate entries in select clauses during execution plan conversion.

# 💡 Solution (How?)

Modified `ProjectNode` visitor to check for existing entries before adding new ones to the select clause.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [x] **Bugfix** - A change that resolves an issue.
