### PR TITLE
Add Column Mapping Logic

### DIFF
--- a/src/main/java/com/miljanilic/executor/mapper/ColumnMapping.java
+++ b/src/main/java/com/miljanilic/executor/mapper/ColumnMapping.java
@@ -1,0 +1,33 @@
+package com.miljanilic.executor.mapper;
+
+import com.miljanilic.sql.ast.expression.Column;
+
+import java.util.List;
+
+public class ColumnMapping {
+    private final int[] columnIndices;
+    private final int[] columnTypes;
+    private final List<Column> orderedColumns;
+
+    public ColumnMapping(int[] columnIndices, int[] columnTypes, List<Column> orderedColumns) {
+        this.columnIndices = columnIndices;
+        this.columnTypes = columnTypes;
+        this.orderedColumns = orderedColumns;
+    }
+
+    public int getColumnIndex(int i) {
+        return columnIndices[i];
+    }
+
+    public int getColumnType(int i) {
+        return columnTypes[i];
+    }
+
+    public String getColumnName(int i) {
+        return orderedColumns.get(i).getName();
+    }
+
+    public int getColumnCount() {
+        return columnIndices.length;
+    }
+}

--- a/src/main/java/com/miljanilic/executor/mapper/ExecutionMappingException.java
+++ b/src/main/java/com/miljanilic/executor/mapper/ExecutionMappingException.java
@@ -1,0 +1,11 @@
+package com.miljanilic.executor.mapper;
+
+public class ExecutionMappingException extends RuntimeException {
+    public ExecutionMappingException(String message) {
+        super(message);
+    }
+
+    public ExecutionMappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/miljanilic/executor/mapper/ResultSetColumnIndexMapper.java
+++ b/src/main/java/com/miljanilic/executor/mapper/ResultSetColumnIndexMapper.java
@@ -1,0 +1,48 @@
+package com.miljanilic.executor.mapper;
+
+import com.miljanilic.sql.ast.expression.Column;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.*;
+
+public class ResultSetColumnIndexMapper {
+
+    public ColumnMapping map(ResultSetMetaData metaData, Set<Column> queryColumns) throws SQLException {
+        Map<String, ColumnInfo> resultSetColumnInfo = extractResultSetColumnInfo(metaData);
+        return createColumnMapping(queryColumns, resultSetColumnInfo);
+    }
+
+    private Map<String, ColumnInfo> extractResultSetColumnInfo(ResultSetMetaData metaData) throws SQLException {
+        Map<String, ColumnInfo> columnInfo = new HashMap<>();
+        for (int i = 1; i <= metaData.getColumnCount(); i++) {
+            String columnName = metaData.getColumnName(i).toLowerCase();
+            int columnType = metaData.getColumnType(i);
+            columnInfo.put(columnName, new ColumnInfo(i, columnType));
+        }
+        return columnInfo;
+    }
+
+    private ColumnMapping createColumnMapping(Set<Column> queryColumns, Map<String, ColumnInfo> resultSetColumnInfo) {
+        List<Column> orderedColumns = new ArrayList<>(queryColumns);
+        int[] columnIndices = new int[orderedColumns.size()];
+        int[] columnTypes = new int[orderedColumns.size()];
+
+        for (int i = 0; i < orderedColumns.size(); i++) {
+            Column column = orderedColumns.get(i);
+            String columnName = column.getName().toLowerCase();
+            ColumnInfo info = resultSetColumnInfo.get(columnName);
+
+            if (info == null) {
+                throw new ExecutionMappingException("Column '" + columnName + "' not found in the result set.");
+            }
+
+            columnIndices[i] = info.index;
+            columnTypes[i] = info.type;
+        }
+
+        return new ColumnMapping(columnIndices, columnTypes, orderedColumns);
+    }
+
+    private record ColumnInfo(int index, int type) { }
+}


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

Introducing a more structured approach to mapping database result set columns to query columns and enhancing flexibility and clarity in handling result sets.

# 💡 Solution (How?)

Added a `ColumnMapping` class to manage column indices, types, and names. Implemented `ResultSetColumnIndexMapper` to map SQL result set metadata to query columns, with error handling through `ExecutionMappingException`. This improves data mapping reliability and simplifies error tracing in execution.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
