### PR TITLE
Add DuckDB Temporary Table Creation

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,9 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="ClassCanBeRecord" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="SqlNoDataSourceInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SqlSourceToSinkFlow" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="VulnerableLibrariesLocal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="isIgnoringEnabled" value="true" />
       <option name="ignoredModules">

--- a/src/main/java/com/miljanilic/executor/table/ColumnDefinition.java
+++ b/src/main/java/com/miljanilic/executor/table/ColumnDefinition.java
@@ -1,0 +1,25 @@
+package com.miljanilic.executor.table;
+
+import com.miljanilic.catalog.data.Column;
+
+public class ColumnDefinition {
+    private final String name;
+    private final Column.ColumnType type;
+
+    public ColumnDefinition(String name, Column.ColumnType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Column.ColumnType getType() {
+        return type;
+    }
+
+    public String toSql() {
+        return name + " " + type;
+    }
+}

--- a/src/main/java/com/miljanilic/executor/table/DuckDbTemporaryTableCreator.java
+++ b/src/main/java/com/miljanilic/executor/table/DuckDbTemporaryTableCreator.java
@@ -1,0 +1,25 @@
+package com.miljanilic.executor.table;
+
+import com.miljanilic.executor.SQLExecutionException;
+import com.miljanilic.sql.ast.expression.Column;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class DuckDbTemporaryTableCreator {
+
+    public void create(Connection connection, TemporaryTable temporaryTable) {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(temporaryTable.toSql());
+        } catch (SQLException e) {
+            throw new SQLExecutionException("Failed creating temporary table: " + temporaryTable.getName(), e);
+        }
+    }
+}

--- a/src/main/java/com/miljanilic/executor/table/DuckDbTemporaryTableDefinitionGenerator.java
+++ b/src/main/java/com/miljanilic/executor/table/DuckDbTemporaryTableDefinitionGenerator.java
@@ -1,0 +1,40 @@
+package com.miljanilic.executor.table;
+
+import com.miljanilic.sql.ast.expression.Column;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class DuckDbTemporaryTableDefinitionGenerator {
+
+    public TemporaryTable generate(Set<Column> columns) {
+        String tableName = generateTableName(columns);
+        List<ColumnDefinition> columnDefinitions = generateColumnDefinitions(columns);
+
+        return new TemporaryTable(tableName, columnDefinitions);
+    }
+
+    private String generateTableName(Set<Column> columns) {
+        SortedSet<String> tableNames = columns.stream()
+                .map(column -> column.getFrom().getSchemaTable().getName())
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        return String.join("_", tableNames);
+    }
+
+    private List<ColumnDefinition> generateColumnDefinitions(Set<Column> columns) {
+        return columns.stream()
+                .map(column -> {
+                    com.miljanilic.catalog.data.Column columnData = column.getFrom().getSchemaTable().getColumns().stream()
+                            .filter(c -> c.getName().equals(column.getName()))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("No matching column data found for " + column.getName()));
+
+                    return new ColumnDefinition(column.getName(), columnData.getType());
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/miljanilic/executor/table/TemporaryTable.java
+++ b/src/main/java/com/miljanilic/executor/table/TemporaryTable.java
@@ -1,0 +1,30 @@
+package com.miljanilic.executor.table;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TemporaryTable {
+    private final String name;
+    private final List<ColumnDefinition> columns;
+
+    public TemporaryTable(String name, List<ColumnDefinition> columns) {
+        this.name = name;
+        this.columns = columns;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<ColumnDefinition> getColumns() {
+        return columns;
+    }
+
+    public String toSql() {
+        String columnDefinitions = columns.stream()
+                .map(ColumnDefinition::toSql)
+                .collect(Collectors.joining(", "));
+
+        return String.format("CREATE TEMPORARY TABLE %s (%s)", name, columnDefinitions);
+    }
+}


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

We need to support the creation of temporary tables in DuckDB.

# 💡 Solution (How?)

Added `DuckDbTemporaryTableCreator`, `TemporaryTable`, and related classes to define and create temporary tables in DuckDB. These classes generate table definitions based on provided column metadata and execute SQL for table creation using JDBC. This simplifies the temporary table creation process and correctly handles SQL execution errors.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
