### PR TITLE
Add Distributed Schema SQL Execution Logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <inject.version>7.0.0</inject.version>
         <jsqlparser.version>5.0</jsqlparser.version>
         <jackson.version>2.17.2</jackson.version>
+        <mysql-connector.version>8.0.33</mysql-connector.version>
+        <duckdb.version>1.1.0</duckdb.version>
     </properties>
 
     <dependencies>
@@ -37,6 +39,20 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql-connector.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.duckdb/duckdb_jdbc -->
+        <dependency>
+            <groupId>org.duckdb</groupId>
+            <artifactId>duckdb_jdbc</artifactId>
+            <version>${duckdb.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/miljanilic/executor/ConcurrentSchemaQueryExecutor.java
+++ b/src/main/java/com/miljanilic/executor/ConcurrentSchemaQueryExecutor.java
@@ -1,0 +1,47 @@
+package com.miljanilic.executor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+
+import java.sql.ResultSet;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.BiConsumer;
+
+@Singleton
+public class ConcurrentSchemaQueryExecutor {
+    private final SchemaQueryExecutor schemaQueryExecutor;
+
+    @Inject
+    public ConcurrentSchemaQueryExecutor(
+            SchemaQueryExecutor schemaQueryExecutor
+    ) {
+        this.schemaQueryExecutor = schemaQueryExecutor;
+    }
+
+    public void executeAll(Map<Schema, SelectStatement> selectStatementMap, BiConsumer<SelectStatement, ResultSet> resultSetConsumer) {
+        try (ExecutorService executorService = Executors.newFixedThreadPool(selectStatementMap.size())) {
+            CountDownLatch latch = new CountDownLatch(selectStatementMap.size());
+
+            for (Map.Entry<Schema, SelectStatement> entry : selectStatementMap.entrySet()) {
+                executorService.submit(() -> {
+                    try {
+                        schemaQueryExecutor.execute(entry.getKey(), entry.getValue(), resultSetConsumer);
+                    } catch (Exception e) {
+                        throw new SQLExecutionException("Distributed query execution failed", e);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+        } catch (Exception e) {
+            throw new SQLExecutionException("Distributed query execution failed", e);
+        }
+    }
+}

--- a/src/main/java/com/miljanilic/executor/SQLExecutionException.java
+++ b/src/main/java/com/miljanilic/executor/SQLExecutionException.java
@@ -1,0 +1,11 @@
+package com.miljanilic.executor;
+
+public class SQLExecutionException extends RuntimeException {
+    public SQLExecutionException(String message) {
+        super(message);
+    }
+
+    public SQLExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/miljanilic/executor/SchemaQueryExecutor.java
+++ b/src/main/java/com/miljanilic/executor/SchemaQueryExecutor.java
@@ -1,0 +1,39 @@
+package com.miljanilic.executor;
+
+import com.google.inject.Inject;
+import com.miljanilic.catalog.data.Schema;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+import com.miljanilic.sql.deparser.SqlDeParser;
+
+import java.sql.*;
+import java.util.function.BiConsumer;
+
+public class SchemaQueryExecutor {
+    private final SqlDeParser sqlDeParser;
+
+
+    @Inject
+    public SchemaQueryExecutor(SqlDeParser sqlDeParser) {
+        this.sqlDeParser = sqlDeParser;
+    }
+
+    public void execute(Schema schema, SelectStatement query, BiConsumer<SelectStatement, ResultSet> resultSetConsumer) {
+        String sql = sqlDeParser.deparse(query);
+
+        try (
+                Connection conn = DriverManager.getConnection(schema.getDataSource().getJdbcUrl(), schema.getDataSource().getJdbcUser(), schema.getDataSource().getJdbcPassword());
+        ) {
+            Statement statement = conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+
+            // TODO: Support other databases.
+            statement.setFetchSize(Integer.MIN_VALUE);  // Enable streaming in MySQL
+
+            try (ResultSet resultSet = statement.executeQuery(sql)) {
+                resultSetConsumer.accept(query, resultSet);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new SQLExecutionException("Error executing SQL query", e);
+        }
+    }
+}


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

We must enable concurrent distributed SQL query execution across multiple schemas to enhance performance and scalability for federated queries.

# 💡 Solution (How?)

Updated `pom.xml` to include dependencies for MySQL and DuckDB JDBC drivers. 

Introduced `ConcurrentSchemaQueryExecutor` to run schema queries in parallel, with `SchemaQueryExecutor` handling individual schema execution using JDBC. Added `SQLExecutionException` to capture and handle SQL execution errors. 

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
