### PR TITLE
Add Remote ResultSet Processing Logic - DuckDB Integration

### DIFF
--- a/src/main/java/com/miljanilic/executor/DuckDbResultSetDataAppender.java
+++ b/src/main/java/com/miljanilic/executor/DuckDbResultSetDataAppender.java
@@ -1,0 +1,59 @@
+package com.miljanilic.executor;
+
+import com.miljanilic.executor.mapper.ColumnMapping;
+import org.duckdb.DuckDBAppender;
+import org.duckdb.DuckDBConnection;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+public class DuckDbResultSetDataAppender {
+
+    public void append(Connection duckDBConnection, String tableName, ResultSet sourceResultSet, ColumnMapping columnMapping) throws SQLExecutionException {
+        try (DuckDBAppender appender = createAppender(duckDBConnection, tableName)) {
+            while (sourceResultSet.next()) {
+                appendRow(appender, sourceResultSet, columnMapping);
+            }
+
+            appender.flush();
+        } catch (SQLException e) {
+            throw new SQLExecutionException("Failed to append ResultSet data to DuckDB", e);
+        }
+    }
+
+    private DuckDBAppender createAppender(Connection duckDBConnection, String tableName) throws SQLException {
+        return ((DuckDBConnection) duckDBConnection).createAppender(DuckDBConnection.DEFAULT_SCHEMA, tableName);
+    }
+
+    private void appendRow(DuckDBAppender appender, ResultSet sourceResultSet, ColumnMapping columnMapping) throws SQLException {
+        appender.beginRow();
+
+        for (int i = 0; i < columnMapping.getColumnCount(); i++) {
+            int resultSetColumnIndex = columnMapping.getColumnIndex(i);
+
+            switch (columnMapping.getColumnType(i)) {
+                case Types.INTEGER:
+                    appender.append(sourceResultSet.getInt(resultSetColumnIndex));
+                    break;
+                case Types.BIGINT:
+                    appender.append(sourceResultSet.getLong(resultSetColumnIndex));
+                    break;
+                case Types.DECIMAL:
+                case Types.DOUBLE:
+                    appender.append(sourceResultSet.getDouble(resultSetColumnIndex));
+                    break;
+                case Types.VARCHAR:
+                case Types.CHAR:
+                case Types.DATE:
+                    appender.append(sourceResultSet.getString(resultSetColumnIndex));
+                    break;
+                default:
+                    throw new SQLException("Unsupported column type: " + columnMapping.getColumnType(i));
+            }
+        }
+
+        appender.endRow();
+    }
+}

--- a/src/main/java/com/miljanilic/executor/DuckDbTemporaryStorageResultSetConsumer.java
+++ b/src/main/java/com/miljanilic/executor/DuckDbTemporaryStorageResultSetConsumer.java
@@ -1,0 +1,71 @@
+package com.miljanilic.executor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.miljanilic.executor.mapper.ColumnMapping;
+import com.miljanilic.executor.mapper.ResultSetColumnIndexMapper;
+import com.miljanilic.executor.table.DuckDbTemporaryTableCreator;
+import com.miljanilic.executor.table.DuckDbTemporaryTableDefinitionGenerator;
+import com.miljanilic.executor.table.TemporaryTable;
+import com.miljanilic.sql.ast.expression.Column;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+import com.miljanilic.sql.ast.visitor.ASTColumnExtractingVisitor;
+import com.miljanilic.sql.deparser.SqlDeParser;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.util.HashSet;
+import java.util.Set;
+
+@Singleton
+public class DuckDbTemporaryStorageResultSetConsumer {
+    private final ResultSetPrinter resultSetPrinter;
+    private final ASTColumnExtractingVisitor columnExtractingVisitor;
+    private final ResultSetColumnIndexMapper columnIndexMapper;
+    private final DuckDbResultSetDataAppender duckDbResultSetDataAppender;
+    private final DuckDbTemporaryTableDefinitionGenerator duckDbTemporaryTableDefinitionGenerator;
+    private final DuckDbTemporaryTableCreator duckDbTemporaryTableCreator;
+
+    @Inject
+    public DuckDbTemporaryStorageResultSetConsumer(
+            ResultSetPrinter resultSetPrinter,
+            ASTColumnExtractingVisitor columnExtractingVisitor,
+            ResultSetColumnIndexMapper columnIndexMapper,
+            DuckDbResultSetDataAppender duckDbResultSetDataAppender,
+            DuckDbTemporaryTableDefinitionGenerator duckDbTemporaryTableDefinitionGenerator,
+            DuckDbTemporaryTableCreator duckDbTemporaryTableCreator
+    ) {
+        this.resultSetPrinter = resultSetPrinter;
+        this.columnExtractingVisitor = columnExtractingVisitor;
+        this.columnIndexMapper = columnIndexMapper;
+        this.duckDbResultSetDataAppender = duckDbResultSetDataAppender;
+        this.duckDbTemporaryTableDefinitionGenerator = duckDbTemporaryTableDefinitionGenerator;
+        this.duckDbTemporaryTableCreator = duckDbTemporaryTableCreator;
+    }
+
+    public void consume(Connection connection, SelectStatement statement, ResultSet resultSet) {
+        try {
+            Set<Column> columns = new HashSet<>(statement.accept(this.columnExtractingVisitor, null));
+            ColumnMapping columnMapping = this.columnIndexMapper.map(resultSet.getMetaData(), columns);
+            TemporaryTable temporaryTable = this.duckDbTemporaryTableDefinitionGenerator.generate(columns);
+
+            this.duckDbTemporaryTableCreator.create(connection, temporaryTable);
+            this.duckDbResultSetDataAppender.append(connection, temporaryTable.getName(), resultSet, columnMapping);
+
+            System.out.println("Data appended successfully into " + temporaryTable.getName());
+
+            String selectSql = "SELECT * FROM " + temporaryTable.getName() + " LIMIT 10";
+
+            try (
+                    java.sql.Statement stmt = connection.createStatement();
+                    ResultSet rs = stmt.executeQuery(selectSql)
+            ) {
+
+                this.resultSetPrinter.print(rs);
+            }
+        } catch (Exception e) {
+            throw new SQLExecutionException("An error occurred while executing SQL in DuckDB", e);
+        }
+    }
+}

--- a/src/main/java/com/miljanilic/executor/ResultSetPrinter.java
+++ b/src/main/java/com/miljanilic/executor/ResultSetPrinter.java
@@ -1,0 +1,45 @@
+package com.miljanilic.executor;
+
+import com.google.inject.Singleton;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+@Singleton
+public class ResultSetPrinter {
+    public void print(ResultSet resultSet) throws SQLException {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        int columnCount = metaData.getColumnCount();
+
+        StringBuilder output = new StringBuilder();
+
+        output.append("+").append("-".repeat(24).repeat(columnCount)).append("+\n");
+
+        output.append("|");
+        for (int i = 1; i <= columnCount; i++) {
+            output.append(String.format(" %-22s|", metaData.getColumnName(i)));
+        }
+        output.append("\n");
+
+        output.append("+").append("-".repeat(24).repeat(columnCount)).append("+\n");
+
+        while (resultSet.next()) {
+            output.append("|");
+            for (int i = 1; i <= columnCount; i++) {
+                String value = resultSet.getString(i);
+                if (value == null) {
+                    value = "NULL";
+                }
+                output.append(String.format(" %-22s|", value));
+            }
+            output.append("\n");
+        }
+
+        output.append("+").append("-".repeat(24).repeat(columnCount)).append("+\n");
+
+        synchronized (System.out) {
+            System.out.print(output);
+        }
+    }
+}


### PR DESCRIPTION
### 🤔 Reason for this change (Why?)

We need support appending and consuming query results into temporary DuckDB tables, enabling efficient intermediate data storage and handling for federated queries.

### 💡 Solution (How?)

Introduced `DuckDbResultSetDataAppender` to append data from a `ResultSet` into DuckDB. 

Added `DuckDbTemporaryStorageResultSetConsumer` to handle the consumption of SQL results, including creating temporary tables, appending data, and displaying the first 10 rows for verification. 

`ResultSetPrinter` was added to print `ResultSet` data in a formatted table style for easier visualization. This ensures smooth integration and visualization of intermediate query results in DuckDB.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
