### PR TITLE
Use Concurrent Schema Query Execution and Execute Aggregation Query

### DIFF
--- a/src/main/java/com/miljanilic/executor/ConcurrentSchemaQueryExecutor.java
+++ b/src/main/java/com/miljanilic/executor/ConcurrentSchemaQueryExecutor.java
@@ -6,7 +6,7 @@ import com.miljanilic.catalog.data.Schema;
 import com.miljanilic.sql.ast.statement.SelectStatement;
 
 import java.sql.ResultSet;
-import java.util.*;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/miljanilic/executor/DuckDbTemporaryStorageResultSetConsumer.java
+++ b/src/main/java/com/miljanilic/executor/DuckDbTemporaryStorageResultSetConsumer.java
@@ -10,10 +10,8 @@ import com.miljanilic.executor.table.TemporaryTable;
 import com.miljanilic.sql.ast.expression.Column;
 import com.miljanilic.sql.ast.statement.SelectStatement;
 import com.miljanilic.sql.ast.visitor.ASTColumnExtractingVisitor;
-import com.miljanilic.sql.deparser.SqlDeParser;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/com/miljanilic/executor/SchemaQueryExecutor.java
+++ b/src/main/java/com/miljanilic/executor/SchemaQueryExecutor.java
@@ -5,7 +5,10 @@ import com.miljanilic.catalog.data.Schema;
 import com.miljanilic.sql.ast.statement.SelectStatement;
 import com.miljanilic.sql.deparser.SqlDeParser;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.function.BiConsumer;
 
 public class SchemaQueryExecutor {

--- a/src/main/java/com/miljanilic/executor/table/DuckDbTemporaryTableCreator.java
+++ b/src/main/java/com/miljanilic/executor/table/DuckDbTemporaryTableCreator.java
@@ -1,17 +1,10 @@
 package com.miljanilic.executor.table;
 
 import com.miljanilic.executor.SQLExecutionException;
-import com.miljanilic.sql.ast.expression.Column;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 public class DuckDbTemporaryTableCreator {
 


### PR DESCRIPTION
### 🤔 Reason for this change (Why?)

We must integrate concurrent schema query execution and DuckDB for temporary data storage, enhancing the application's ability to handle distributed queries and aggregate results from multiple schemas.

### 💡 Solution (How?)

Updated the `Application` class to utilize `ConcurrentSchemaQueryExecutor` and `DuckDbTemporaryStorageResultSetConsumer` for executing and consuming results across multiple schemas. 

Added a connection to DuckDB for handling temporary tables and storing intermediate query results. 

Modified the flow to print the created tables in DuckDB and their contents.
# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
