### PR TITLE
Add Cassandra as Example Database

### DIFF
--- a/benchmark/generator.py
+++ b/benchmark/generator.py
@@ -244,7 +244,7 @@ def populate_data(num_users, num_products, num_orders, num_order_items, num_acti
 
 try:
     create_databases_and_tables()
-    populate_data(1000000, 10000, 2500000, 5000000, 15000000)
+    populate_data(1000000, 10000, 5000000, 10000000, 50000000)
 except Exception as e:
     logging.error(f"An error occurred: {e}")
 

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -9,13 +9,15 @@ services:
     volumes:
       - db_mysql_data:/var/lib/mysql
 
-  mongodb:
-    image: mongo:7.0
+  cassandra:
+    image: cassandra:5.0
     ports:
-      - "27017:27017"
+      - "9042:9042"
+    environment:
+      - CASSANDRA_CLUSTER_NAME=ClusterZero
     volumes:
-      - db_mongodb_data:/data/db
+      - db_cassandra_data:/var/lib/cassandra
 
 volumes:
   db_mysql_data:
-  db_mongodb_data:
+  db_cassandra_data:

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
         <jackson.version>2.17.2</jackson.version>
         <mysql-connector.version>8.0.33</mysql-connector.version>
         <duckdb.version>1.1.0</duckdb.version>
+        <cassandra.version>4.13.1</cassandra.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <logback.version>1.5.8</logback.version>
     </properties>
 
     <dependencies>
@@ -53,6 +56,26 @@
             <groupId>org.duckdb</groupId>
             <artifactId>duckdb_jdbc</artifactId>
             <version>${duckdb.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ing.data</groupId>
+            <artifactId>cassandra-jdbc-wrapper</artifactId>
+            <version>${cassandra.version}</version>
+        </dependency>
+
+        <!-- SLF4J API -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <!-- Logback implementation -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

Performance scaling adjustments must be made to increase data volume for more realistic benchmarking. Cassandra, replacing MongoDB, was added as an example database for benchmarking a federated approach. Logging improvements were introduced for better visibility.

# 💡 Solution (How?)

The `populate_data()` function was updated for larger datasets. Docker Compose was reconfigured to use Cassandra, and dependencies for Cassandra JDBC were added in `pom.xml`. SLF4J and Logback were introduced for improved logging, with a new `logback.xml` file for configuration.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [ ] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
