### PR TITLE
Add Execution Timer

### DIFF
--- a/src/main/java/com/miljanilic/Application.java
+++ b/src/main/java/com/miljanilic/Application.java
@@ -21,6 +21,8 @@ import com.miljanilic.sql.parser.SqlParser;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 public class Application {
@@ -55,6 +57,8 @@ public class Application {
         Scanner scanner = new Scanner(System.in);
 
         String sql = scanner.nextLine();
+
+        Instant start = Instant.now();
 
         try {
             Statement statement = sqlParser.parse(sql);
@@ -124,5 +128,8 @@ public class Application {
         } catch (Exception e) {
             System.out.println("Error executing SQL: " + e.getMessage());
         }
+
+        Instant finish = Instant.now();
+        System.out.println("Time Elapsed: " + Duration.between(start, finish).toMillis() + "ms");
     }
 }

--- a/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlExpressionVisitor.java
+++ b/src/main/java/com/miljanilic/sql/deparser/visitor/AstToJSqlExpressionVisitor.java
@@ -19,7 +19,6 @@ import net.sf.jsqlparser.statement.select.FromItem;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Singleton
 public class AstToJSqlExpressionVisitor extends ASTVisitorAdapter<Expression, Void> {
@@ -35,10 +34,8 @@ public class AstToJSqlExpressionVisitor extends ASTVisitorAdapter<Expression, Vo
         FromItem jsqlFromItem = column.getFrom().accept(fromItemVisitor, null);
         Table jsqlTable = null;
 
-        if (Objects.equals(column.getFrom().getSchema().getDataSource().getJdbcDriver(), "com.mysql.cj.jdbc.Driver")) {
-            if (jsqlFromItem instanceof Table) {
-                jsqlTable = (Table) jsqlFromItem;
-            }
+        if (jsqlFromItem instanceof Table) {
+            jsqlTable = (Table) jsqlFromItem;
         }
 
         return new Column(


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

Added time measurement to track SQL execution performance and cleaned up unnecessary code for better readability.

##💡 Solution (How?)

Inserted start and finish time measurements using `Instant` to calculate the time elapsed during SQL execution. Removed redundant `Objects.equals` check to simplify the code in the `AstToJSqlExpressionVisitor` class.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [x] **New Feature** - A change that adds functionality.
- [x] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
