### PR TITLE
Remove Self JOIN When Joining Localy

### DIFF
--- a/src/main/java/com/miljanilic/catalog/data/Table.java
+++ b/src/main/java/com/miljanilic/catalog/data/Table.java
@@ -1,6 +1,7 @@
 package com.miljanilic.catalog.data;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class Table {
@@ -53,6 +54,18 @@ public class Table {
     public enum TableType {
         TABLE,
         VIEW
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Table table)) return false;
+        return Objects.equals(name, table.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
     }
 
     @Override

--- a/src/main/java/com/miljanilic/planner/filter/ExecutionPlanAggregationNodeFilter.java
+++ b/src/main/java/com/miljanilic/planner/filter/ExecutionPlanAggregationNodeFilter.java
@@ -1,8 +1,6 @@
 package com.miljanilic.planner.filter;
 
 import com.miljanilic.planner.node.*;
-import com.miljanilic.sql.ast.expression.Column;
-import com.miljanilic.sql.ast.expression.binary.EqualsTo;
 import com.miljanilic.sql.ast.node.Table;
 
 import java.util.SortedSet;
@@ -50,28 +48,9 @@ public class ExecutionPlanAggregationNodeFilter extends ExecutionPlanFilterAdapt
                 tableNames.add(leftScanNode.getFrom().getSchemaTable().getName());
                 tableNames.add(rightScanNode.getFrom().getSchemaTable().getName());
 
-                ScanNode leftLocalScanNode = new ScanNode(
-                        new Table(leftScanNode.getSchema(), null, String.join("_", tableNames), leftScanNode.getFrom().getSchemaTable().getName()),
+                return new ScanNode(
+                        new Table(leftScanNode.getSchema(), null, String.join("_", tableNames), null),
                         null
-                );
-
-                ScanNode rightLocalScanNode = new ScanNode(
-                        new Table(rightScanNode.getSchema(), null, String.join("_", tableNames), rightScanNode.getFrom().getSchemaTable().getName()),
-                        null
-                );
-
-                Table leftTable = new Table(leftScanNode.getSchema(), null, leftScanNode.getFrom().getSchemaTable().getName(), null);
-                Table rightTable = new Table(rightScanNode.getSchema(), null, rightScanNode.getFrom().getSchemaTable().getName(), null);
-
-                return new JoinNode(
-                        leftLocalScanNode,
-                        rightLocalScanNode,
-                        node.getJoinType(),
-                        new EqualsTo(
-                                new Column("id", leftTable),
-                                new Column("id", rightTable)
-                        ),
-                        node.getAlgorithm()
                 );
             }
         }

--- a/src/main/java/com/miljanilic/planner/visitor/ApplyRemoteJoinMapExecutionPlanVisitor.java
+++ b/src/main/java/com/miljanilic/planner/visitor/ApplyRemoteJoinMapExecutionPlanVisitor.java
@@ -1,0 +1,99 @@
+package com.miljanilic.planner.visitor;
+
+import com.miljanilic.planner.ExecutionPlanVisitor;
+import com.miljanilic.planner.node.*;
+import com.miljanilic.sql.ast.ASTVisitor;
+import com.miljanilic.sql.ast.expression.Expression;
+import com.miljanilic.sql.ast.expression.Function;
+import com.miljanilic.sql.ast.node.OrderBy;
+import com.miljanilic.sql.ast.node.Select;
+
+import java.util.List;
+
+public class ApplyRemoteJoinMapExecutionPlanVisitor implements ExecutionPlanVisitor<Void, Void> {
+    private final ASTVisitor<Void, Void> astVisitor;
+
+    public ApplyRemoteJoinMapExecutionPlanVisitor(
+            ASTVisitor<Void, Void> astVisitor
+    ) {
+        this.astVisitor = astVisitor;
+    }
+
+    @Override
+    public Void visit(ScanNode node, Void context) {
+        node.getFrom().accept(astVisitor, null);
+
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(FilterNode node, Void context) {
+        node.getCondition().accept(astVisitor, null);
+
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(JoinNode node, Void context) {
+        node.getCondition().accept(astVisitor, null);
+
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(ProjectNode node, Void context) {
+        for (Select select : node.getSelectList()) {
+            select.accept(astVisitor, context);
+        }
+
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(AggregateNode node, Void context) {
+        for (Function function : node.getAggregateFunctions()) {
+            function.accept(astVisitor, context);
+        }
+
+        for (Expression expression : node.getGroupByExpressions()) {
+            expression.accept(astVisitor, context);
+        }
+
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(SortNode node, Void context) {
+        for (OrderBy orderBy : node.getOrderByList()) {
+            orderBy.accept(astVisitor, null);
+        }
+
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(LimitNode node, Void context) {
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(HavingNode node, Void context) {
+        node.getCondition().accept(astVisitor, context);
+
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    private void visitChildren(List<PlanNode> children, Void context) {
+        for (PlanNode child : children) {
+            child.accept(this, context);
+        }
+    }
+}

--- a/src/main/java/com/miljanilic/planner/visitor/RemoteJoinMapExecutionPlanVisitor.java
+++ b/src/main/java/com/miljanilic/planner/visitor/RemoteJoinMapExecutionPlanVisitor.java
@@ -22,7 +22,6 @@ public class RemoteJoinMapExecutionPlanVisitor implements ExecutionPlanVisitor<V
 
     @Override
     public Void visit(JoinNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
-        System.out.println("OK");
         if (node instanceof RemoteJoinNode remoteJoinNode) {
             if (remoteJoinNode.getLeft() instanceof RemoteScanNode leftScanNode && remoteJoinNode.getRight() instanceof RemoteScanNode rightScanNode) {
                 SortedSet<String> tableNames = new TreeSet<>();

--- a/src/main/java/com/miljanilic/planner/visitor/RemoteJoinMapExecutionPlanVisitor.java
+++ b/src/main/java/com/miljanilic/planner/visitor/RemoteJoinMapExecutionPlanVisitor.java
@@ -1,0 +1,78 @@
+package com.miljanilic.planner.visitor;
+
+import com.miljanilic.catalog.data.Table;
+import com.miljanilic.planner.ExecutionPlanVisitor;
+import com.miljanilic.planner.node.*;
+
+import java.util.*;
+
+public class RemoteJoinMapExecutionPlanVisitor implements ExecutionPlanVisitor<Void, Map<Table, com.miljanilic.sql.ast.node.Table>> {
+
+    @Override
+    public Void visit(ScanNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(FilterNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(JoinNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        System.out.println("OK");
+        if (node instanceof RemoteJoinNode remoteJoinNode) {
+            if (remoteJoinNode.getLeft() instanceof RemoteScanNode leftScanNode && remoteJoinNode.getRight() instanceof RemoteScanNode rightScanNode) {
+                SortedSet<String> tableNames = new TreeSet<>();
+                tableNames.add(leftScanNode.getFrom().getSchemaTable().getName());
+                tableNames.add(rightScanNode.getFrom().getSchemaTable().getName());
+
+                com.miljanilic.sql.ast.node.Table virtualTable = new com.miljanilic.sql.ast.node.Table(leftScanNode.getSchema(), null, String.join("_", tableNames), null);
+
+                context.put(leftScanNode.getFrom().getSchemaTable(), virtualTable);
+                context.put(rightScanNode.getFrom().getSchemaTable(), virtualTable);
+            }
+        }
+
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(ProjectNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(AggregateNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(SortNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(LimitNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    @Override
+    public Void visit(HavingNode node, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        visitChildren(node.getChildren(), context);
+        return null;
+    }
+
+    private void visitChildren(List<PlanNode> children, Map<Table, com.miljanilic.sql.ast.node.Table> context) {
+        for (PlanNode child : children) {
+            child.accept(this, context);
+        }
+    }
+}

--- a/src/main/java/com/miljanilic/sql/ast/expression/Column.java
+++ b/src/main/java/com/miljanilic/sql/ast/expression/Column.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 
 public class Column extends Expression {
     private final String name;
-    private final From from;
+    private From from;
 
     public Column(String name, From from) {
         this.name = name;
@@ -20,6 +20,10 @@ public class Column extends Expression {
 
     public From getFrom() {
         return from;
+    }
+
+    public void setFrom(From from) {
+        this.from = from;
     }
 
     @Override

--- a/src/main/java/com/miljanilic/sql/ast/visitor/ASTFromReplacingVisitor.java
+++ b/src/main/java/com/miljanilic/sql/ast/visitor/ASTFromReplacingVisitor.java
@@ -1,0 +1,241 @@
+package com.miljanilic.sql.ast.visitor;
+
+import com.miljanilic.sql.ast.ASTVisitor;
+import com.miljanilic.sql.ast.clause.*;
+import com.miljanilic.sql.ast.expression.*;
+import com.miljanilic.sql.ast.expression.binary.*;
+import com.miljanilic.sql.ast.node.*;
+import com.miljanilic.sql.ast.statement.SelectStatement;
+
+import java.util.Map;
+
+public class ASTFromReplacingVisitor implements ASTVisitor<Void, Void> {
+    private final Map<com.miljanilic.catalog.data.Table, Table> remoteJoinMap;
+
+    public ASTFromReplacingVisitor(Map<com.miljanilic.catalog.data.Table, Table> remoteJoinMap) {
+        this.remoteJoinMap = remoteJoinMap;
+    }
+
+    @Override
+    public Void visit(SelectStatement statement, Void context) {
+        statement.getSelectClause().accept(this, context);
+        statement.getFromClause().accept(this, context);
+
+        if (statement.getJoinClause() != null) {
+           statement.getJoinClause().accept(this, context);
+        }
+
+        if (statement.getWhereClause() != null) {
+            statement.getWhereClause().accept(this, context);
+        }
+
+        if (statement.getGroupByClause() != null) {
+            statement.getGroupByClause().accept(this, context);
+        }
+
+        if (statement.getHavingClause() != null) {
+            statement.getHavingClause().accept(this, context);
+        }
+
+        if (statement.getOrderByClause() != null) {
+            statement.getOrderByClause().accept(this, context);
+        }
+
+        if (statement.getLimitClause() != null) {
+            statement.getLimitClause().accept(this, context);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(SelectClause clause, Void context) {
+        for (Select select : clause.getSelectList()) {
+            select.accept(this, context);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(FromClause clause, Void context) {
+        return clause.getFrom().accept(this, context);
+    }
+
+    @Override
+    public Void visit(JoinClause clause, Void context) {
+        for (Join join : clause.getJoinList()) {
+            join.accept(this, context);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(WhereClause clause, Void context) {
+        return clause.getCondition().accept(this, context);
+    }
+
+    @Override
+    public Void visit(GroupByClause clause, Void context) {
+        return clause.getGroupBy().accept(this, context);
+    }
+
+    @Override
+    public Void visit(HavingClause clause, Void context) {
+        return clause.getCondition().accept(this, context);
+    }
+
+    @Override
+    public Void visit(OrderByClause clause, Void context) {
+        for (OrderBy orderBy : clause.getOrderByList()) {
+            orderBy.accept(this, context);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(LimitClause clause, Void context) {
+        if (clause.getOffset() != null) {
+            clause.getOffset().accept(this, context);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(Table table, Void context) {
+        return null;
+    }
+
+    @Override
+    public Void visit(Join expression, Void context) {
+        expression.getFrom().accept(this, context);
+        expression.getConditions().accept(this, context);
+
+        return null;
+    }
+
+    @Override
+    public Void visit(Column expression, Void context) {
+        From from = expression.getFrom();
+
+        if (this.remoteJoinMap.containsKey(from.getSchemaTable())) {
+            expression.setFrom(this.remoteJoinMap.get(from.getSchemaTable()));
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(Function expression, Void context) {
+        return expression.getArguments().accept(this, context);
+    }
+
+    @Override
+    public Void visit(LongValue expression, Void context) {
+        return null;
+    }
+
+    @Override
+    public Void visit(StringValue expression, Void context) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EqualsTo expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(NotEqualsTo expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(GreaterThan expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(GreaterThanEquals expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(LessThan expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(LessThanEquals expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(AndOperator expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(OrOperator expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(Addition expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(Subtraction expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(Multiplication expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(Division expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(Modulo expression, Void context) {
+        return visitBinaryExpression(expression);
+    }
+
+    @Override
+    public Void visit(ExpressionList expression, Void context) {
+        for (Expression expr : expression.getExpressions()) {
+            expr.accept(this, context);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visit(Select select, Void context) {
+        return select.getExpression().accept(this, context);
+    }
+
+    @Override
+    public Void visit(OrderBy orderBy, Void context) {
+        return orderBy.getExpression().accept(this, context);
+    }
+
+    @Override
+    public Void visit(GroupBy groupBy, Void context) {
+        return groupBy.getExpression().accept(this, context);
+    }
+
+    private Void visitBinaryExpression(Binary expression) {
+        expression.getLeft().accept(this, null);
+        expression.getRight().accept(this, null);
+
+        return null;
+    }
+}


### PR DESCRIPTION
# 🤔 Reason for this change (Why?)

This change implements remote join mapping to optimize query execution across distributed tables. It addresses performance issues with cross-database joins by creating virtual tables representing joined data from multiple sources.

# 💡 Solution (How?)

The solution introduces new visitor classes to extract and apply remote join mappings. It modifies the execution plan to replace physical table references with virtual tables, allowing for more efficient query processing. The implementation includes updates to the execution plan filters, AST visitors, and core data structures to support this new join optimization strategy.

# 💥 Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] **New Feature** - A change that adds functionality.
- [x] **Tweak** - A change that tweaks existing features.
- [ ] **Bugfix** - A change that resolves an issue.
